### PR TITLE
fixed mismatch between mask and batch dimensions

### DIFF
--- a/eole/utils/loss.py
+++ b/eole/utils/loss.py
@@ -251,9 +251,8 @@ class LossCompute(nn.Module):
             batch: The current batch.
         """
         # Create a mask with zeros at prompt positions and ones at answer postions.
-        mask = batch["src"].squeeze(dim=2) == self.padding_idx
+        mask = batch["src"].squeeze(dim=-1) == self.padding_idx
         mask = torch.cumsum(mask.int(), 1)
-        mask = mask.unsqueeze(-1)
         # Apply the mask on the target side.
         batch["tgt"] *= mask.int()
         # Put the padding token index at the prompt positions.


### PR DESCRIPTION
The 'zero-out-prompt-loss' is broken because of a mismatch between the mask and tgt side of the the batch
I have tested the fix a a simple example:
```txt
Bonjour les amis ### Response: ｟newline｠bonjour !
```
I have printed in the ignore_prompt method of the  `LossCompute` class:
```python
# mask 
tensor([[0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]], device='cuda:0')
# batch["tgt"] before masking
tensor([[ 82682,   3626,  87893,  17011,  94768,     26,    721,    189,   6099,
          30363,    759, 128002]], device='cuda:0')
# batch["tgt"] after masking
tensor([[   189,    189,    189,    189,    189,    189,    189,    189,   6099,
          30363,    759, 128002]], device='cuda:0')
```
