### PR TITLE
Fix the tokenizer saving in the HF converter

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -234,7 +234,7 @@ class LlamaHFConverter(BaseBin):
                     repo_id=args.model_dir,
                     filename="tokenizer.model",
                     token=args.token,
-                    local_dir=args.output
+                    local_dir=args.output,
                 )
             except huggingface_hub.utils.EntryNotFoundError:
                 try:
@@ -242,7 +242,7 @@ class LlamaHFConverter(BaseBin):
                         repo_id=args.model_dir,
                         filename="tokenizer.json",
                         token=args.token,
-                        local_dir=args.output
+                        local_dir=args.output,
                     )
                     tokenizer_model = None
                 except huggingface_hub.utils.EntryNotFoundError:

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -234,6 +234,7 @@ class LlamaHFConverter(BaseBin):
                     repo_id=args.model_dir,
                     filename="tokenizer.model",
                     token=args.token,
+                    local_dir=args.output
                 )
             except huggingface_hub.utils.EntryNotFoundError:
                 try:
@@ -241,6 +242,7 @@ class LlamaHFConverter(BaseBin):
                         repo_id=args.model_dir,
                         filename="tokenizer.json",
                         token=args.token,
+                        local_dir=args.output
                     )
                     tokenizer_model = None
                 except huggingface_hub.utils.EntryNotFoundError:


### PR DESCRIPTION
With this small fix, `eole convert HF`  will save the tokenizer to the `--output` directory, when it is downloaded from a huggingface folder.