### PR TITLE
MHA refac: rope without complex operations + query only as input of the forward

### DIFF
--- a/eole/decoders/transformer_base.py
+++ b/eole/decoders/transformer_base.py
@@ -125,22 +125,6 @@ class TransformerDecoderLayerBase(nn.Module):
             dec_mask = tgt_pad_mask
         return dec_mask
 
-    def _forward_self_attn(self, norm_layer_in, dec_mask, step, return_attn=False):
-        if self.self_attn_type in ["scaled-dot", "scaled-dot-flash"]:
-            return self.self_attn(
-                norm_layer_in,
-                norm_layer_in,
-                norm_layer_in,
-                mask=dec_mask,
-                sliding_window=self.sliding_window,
-                step=step,
-                return_attn=return_attn,
-            )
-        elif self.self_attn_type == "average":
-            return self.self_attn(norm_layer_in, mask=dec_mask, step=step)
-        else:
-            raise ValueError(f"self attention {type(self.self_attn)} not supported")
-
 
 class TransformerDecoderBase(DecoderBase):
     def __init__(

--- a/eole/decoders/transformer_lm_decoder.py
+++ b/eole/decoders/transformer_lm_decoder.py
@@ -53,9 +53,14 @@ class TransformerLMDecoderLayer(TransformerDecoderLayerBase):
 
         norm_layer_in = self.input_layernorm(layer_in)
 
-        attn_output, attns = self._forward_self_attn(
-            norm_layer_in, dec_mask, step, return_attn=return_attn
+        attn_output, attns = self.self_attn(
+            norm_layer_in,
+            mask=dec_mask,
+            sliding_window=self.sliding_window,
+            step=step,
+            return_attn=return_attn,
         )
+
         if self.dropout_p > 0:
             attn_output = self.dropout(attn_output)
         if self.parallel_residual:
@@ -156,7 +161,6 @@ class TransformerLMDecoder(TransformerDecoderBase):
                         "key_pad_mask": mask,
                     },
                 )
-                if hasattr(layer.self_attn, "rope"):
-                    layer.self_attn.rope = layer.self_attn.rope.to(device)
+                if hasattr(layer.self_attn, "cos") and layer.self_attn.cos is not None:
                     layer.self_attn.cos = layer.self_attn.cos.to(device)
                     layer.self_attn.sin = layer.self_attn.sin.to(device)

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -57,9 +57,7 @@ class TransformerEncoderLayer(nn.Module):
             * layer_out ``(batch_size, src_len, model_dim)``
         """
         norm_layer_in = self.input_layernorm(layer_in)
-        context, _ = self.self_attn(
-            norm_layer_in, norm_layer_in, norm_layer_in, mask=mask
-        )
+        context, _ = self.self_attn(norm_layer_in, mask=mask)
         if self.dropout_p > 0:
             context = self.dropout(context)
         if self.parallel_residual:


### PR DESCRIPTION
Regarding the rope refac posting here the logic for legacy:

```
import torch

dim = 16
base = 10000
maxseqlen = 2048


def rotate_half(x):
    """Rotates half the hidden dims of the input."""
    x1 = x[..., : x.shape[-1] // 2]
    x2 = x[..., x.shape[-1] // 2 :]
    return torch.cat((-x2, x1), dim=-1)

inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
tmax = torch.arange(maxseqlen, device=inv_freq.device)
rope = torch.outer(tmax, inv_freq).float()
# rope is now matrix [maxseqlen, dim/2]

cos_emb = torch.cos(rope)
sin_emb = torch.sin(rope)


rope1 = torch.polar(torch.ones_like(rope), rope)
rope1 = torch.cat((rope1, rope1), dim=1)
print(rope1.size()) # [2048, 16]
start_pos = 4

query = torch.randn(8, 4, 7, 16)


#OLD CODE from llama logic (using complex operators)
query_ = query.float().reshape(8, 4, 7, -1, 2) # [8, 4, 7, 8, 2]
print(query_.size(), query_)
query_ = torch.view_as_complex(query_)
print(query_.size(), query_) # [8, 4, 7, 8] but each is a complex a + bj
print(rope1.size())
rope1 = rope1[start_pos:start_pos+query_.size(2), :rope1.size(1) //2].view(1, 1, query_.size(2), query_.size(3))
print(rope1.size()) # [1, 1, 7, 8]
print(query_ * rope1)
query_out = torch.view_as_real(query_ * rope1).flatten(3)
print(query_out.size(), query_out) # [8, 4, 7, 16]


# same maths but with cos/sin only
query_interleaved = query.reshape(query.shape[0], query.shape[1], query.shape[2], -1, 2)
print(query_interleaved.size())
cos_pos = cos_emb[start_pos:start_pos + query_interleaved.size(2)]
sin_pos = sin_emb[start_pos:start_pos + query_interleaved.size(2)]
print(cos_pos.size(), sin_pos.size())

# Apply rotary embeddings using cosine and sine functions
q_embed_cos = query_interleaved[..., 0] * cos_pos - query_interleaved[..., 1] * sin_pos
q_embed_sin = query_interleaved[..., 0] * sin_pos + query_interleaved[..., 1] * cos_pos

# Combine cosine and sine embeddings
q_embed = torch.stack((q_embed_cos, q_embed_sin), dim=-1)

# Flatten and reshape the output
query_out1 = q_embed.flatten(3)
print(query_out1.size(), query_out1)

print(torch.allclose(query_out, query_out1))
```