### PR TITLE
review flash/sdpa arg

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -240,7 +240,7 @@ jobs:
       run: |
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -252,7 +252,7 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 1 \
@@ -266,7 +266,7 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 3 \
@@ -280,7 +280,7 @@ jobs:
     - name: Test LM generation with random sampling multi-beams
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -298,7 +298,7 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
           -model eole/tests/test_model_lm \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -model_task lm \
           -input_file /tmp/src-test.txt \
           -inference_config_file eole/tests/data/inference-engine_py.yaml \
@@ -318,7 +318,7 @@ jobs:
       run: |
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -model eole/tests/test_model \
           -model_task seq2seq \
           -input_file /tmp/src-test.txt \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -233,14 +233,12 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \
           -src /tmp/src-test.txt \
           -verbose
     - name: Test LM generation with beam search
       run: |
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -252,7 +250,6 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
-          -self_attn_backend pytorch \
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 1 \
@@ -266,7 +263,6 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
-          -self_attn_backend pytorch \
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 3 \
@@ -280,7 +276,6 @@ jobs:
     - name: Test LM generation with random sampling multi-beams
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -298,7 +293,6 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
           -model eole/tests/test_model_lm \
-          -self_attn_backend pytorch \
           -model_task lm \
           -input_file /tmp/src-test.txt \
           -inference_config_file eole/tests/data/inference-engine_py.yaml \
@@ -318,7 +312,6 @@ jobs:
       run: |
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
-          -self_attn_backend pytorch \
           -model eole/tests/test_model \
           -model_task seq2seq \
           -input_file /tmp/src-test.txt \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -233,7 +233,7 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
-          -self_attn_backend pytorch \ 
+          -self_attn_backend pytorch \
           -src /tmp/src-test.txt \
           -verbose
     - name: Test LM generation with beam search

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,7 +107,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "lambda_align": 0.05, "alignment_layer": 2, "alignment_heads": 0, "heads": 2}}' \
-          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "dropout_steps": [0, 3, 7], "dropout": [0.3, 0.2, 0.1], "attention_dropout": [0.2, 0.2, 0.1]}' \
+          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "dropout_steps": [0, 3, 7], "dropout": [0.3, 0.2, 0.1], "attention_dropout": [0.2, 0.2, 0.1]}' \
           -report_every 5 \
     - name : Test Transformer training and validation with dynamic scoring
       run: |
@@ -118,7 +118,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding": True}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2}}' \
-          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5, "accum_count": [2, 4, 8], "accum_steps": [0, 3, 7], "model_path": "/tmp/eole.model"}' \
+          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5, "accum_count": [2, 4, 8], "accum_steps": [0, 3, 7], "model_path": "/tmp/eole.model"}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -135,7 +135,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": 8, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -152,7 +152,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -1, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -169,7 +169,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -2, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -184,7 +184,7 @@ jobs:
             -src_vocab /tmp/eole.vocab.src \
             -tgt_vocab /tmp/eole.vocab.src \
             -model '{"hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16}, "encoder": None, "decoder": {"decoder_type": "transformer_lm", "layers": 2, "heads": 4}}' \
-            -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
+            -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
             -report_every 5

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,7 +107,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "lambda_align": 0.05, "alignment_layer": 2, "alignment_heads": 0, "heads": 2}}' \
-          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "dropout_steps": [0, 3, 7], "dropout": [0.3, 0.2, 0.1], "attention_dropout": [0.2, 0.2, 0.1]}' \
+          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "dropout_steps": [0, 3, 7], "dropout": [0.3, 0.2, 0.1], "attention_dropout": [0.2, 0.2, 0.1]}' \
           -report_every 5 \
     - name : Test Transformer training and validation with dynamic scoring
       run: |
@@ -118,7 +118,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding": True}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2}}' \
-          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5, "accum_count": [2, 4, 8], "accum_steps": [0, 3, 7], "model_path": "/tmp/eole.model"}' \
+          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5, "accum_count": [2, 4, 8], "accum_steps": [0, 3, 7], "model_path": "/tmp/eole.model"}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -135,7 +135,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": 8, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -152,7 +152,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -1, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -169,7 +169,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -2, "embeddings": {"word_vec_size": 16}}' \
-          -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
+          -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
           -tensorboard \
@@ -184,7 +184,7 @@ jobs:
             -src_vocab /tmp/eole.vocab.src \
             -tgt_vocab /tmp/eole.vocab.src \
             -model '{"hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16}, "encoder": None, "decoder": {"decoder_type": "transformer_lm", "layers": 2, "heads": 4}}' \
-            -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
+            -training '{"self_attn_backend": "pytorch", "batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
             -report_every 5
@@ -233,12 +233,14 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
+          -self_attn_backend pytorch \ 
           -src /tmp/src-test.txt \
           -verbose
     - name: Test LM generation with beam search
       run: |
         python eole/bin/main.py predict \
           -model_path eole/tests/test_model_lm \
+          -self_attn_backend pytorch \ 
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -250,6 +252,7 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
+          -self_attn_backend pytorch \ 
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 1 \
@@ -263,6 +266,7 @@ jobs:
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
           -src eole/tests/data/data_lm/src-gen.txt \
+          -self_attn_backend pytorch \ 
           -verbose -batch_size 1 \
           -beam_size 1 \
           -seed 3 \
@@ -276,6 +280,7 @@ jobs:
     - name: Test LM generation with random sampling multi-beams
       run: |
         python eole/bin/main.py predict -model_path eole/tests/test_model_lm \
+          -self_attn_backend pytorch \ 
           -src eole/tests/data/data_lm/src-gen.txt \
           -verbose -batch_size 1 \
           -beam_size 10 \
@@ -293,6 +298,7 @@ jobs:
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
           -model eole/tests/test_model_lm \
+          -self_attn_backend pytorch \ 
           -model_task lm \
           -input_file /tmp/src-test.txt \
           -inference_config_file eole/tests/data/inference-engine_py.yaml \
@@ -312,6 +318,7 @@ jobs:
       run: |
         head eole/tests/data/src-test.txt > /tmp/src-test.txt
         python eole/tests/test_inference_engines.py \
+          -self_attn_backend pytorch \ 
           -model eole/tests/test_model \
           -model_task seq2seq \
           -input_file /tmp/src-test.txt \

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -847,7 +847,6 @@ class LlamaHFConverter(BaseBin):
                 layer_norm=layer_norm,
                 norm_eps=norm_eps,
                 mlp_activation_fn=mlp_activation_fn,
-                self_attn_type="scaled-dot-flash",
                 max_relative_positions=-1,
                 rotary_interleave=rotary_interleave,
                 rotary_theta=rope_theta,

--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -149,7 +149,7 @@ class RunningConfig(DistributedConfig):
             ):
                 pass
             else:
-                self.self_attn_backend = "pytorch"
+                self.__dict__["self_attn_backend"] = "pytorch"
         except ImportError:
-            self.self_attn_backend = "pytorch"
+            self.__dict__["self_attn_backend"] = "pytorch"
         return self

--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -149,7 +149,7 @@ class RunningConfig(DistributedConfig):
             ):
                 pass
             else:
-                self.self_attn_backend == "pytorch"
+                self.self_attn_backend = "pytorch"
         except ImportError:
-            self.self_attn_backend == "pytorch"
+            self.self_attn_backend = "pytorch"
         return self

--- a/eole/config/inference.py
+++ b/eole/config/inference.py
@@ -149,10 +149,6 @@ class InferenceConfig(RunningConfig, DecodingConfig, LoRaConfig, QuantizeConfig)
         "Otherwise, the log probabilities will be averaged directly. "
         "Necessary for models whose output layers can assign zero probability.",
     )
-    self_attn_type: Literal["scaled-dot-flash", "scaled-dot"] = Field(
-        default="scaled-dot-flash",
-        description="Self-attention type in Transformer decoder.",
-    )  # duplicate from the model one (current conflict in legacy code), better solution?
     data_type: str | None = (
         "text"  # deprecated? hopefully will change with input streams logic
     )

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -135,10 +135,6 @@ class TransformerConfig(Config):
     encoder/decoder values with model values if relevant.
     """
 
-    self_attn_type: Literal["scaled-dot-flash", "scaled-dot"] = Field(
-        default="scaled-dot-flash",
-        description="Self attention type in Transformer decoder layer.",
-    )
     sliding_window: int = Field(
         default=0, description="Sliding window for transformer self-attention."
     )
@@ -221,10 +217,6 @@ class TransformerEncoderConfig(TransformerConfig, EncoderConfig):
     encoder_type: Literal["transformer"] = Field(
         default="transformer"
     )  # not sure it's fully proper use, but inspired from docs -- https://docs.pydantic.dev/latest/concepts/fields/#discriminator # noqa: E501
-    self_attn_type: Literal["scaled-dot-flash", "scaled-dot"] = Field(
-        default="scaled-dot-flash",
-        description="Self attention type in Transformer encoder layer.",
-    )
 
 
 class TransformerDecoderConfig(TransformerConfig, DecoderConfig):

--- a/eole/decoders/transformer_base.py
+++ b/eole/decoders/transformer_base.py
@@ -30,7 +30,6 @@ class TransformerDecoderLayerBase(nn.Module):
         self.full_context_alignment = model_config.full_context_alignment
         self.alignment_heads = model_config.alignment_heads
         self.sliding_window = model_config.sliding_window
-        self.self_attn_type = model_config.self_attn_type
 
         self.input_layernorm = LayerNorm[model_config.layer_norm](
             model_config.hidden_size, eps=model_config.norm_eps

--- a/eole/modules/multi_headed_attn.py
+++ b/eole/modules/multi_headed_attn.py
@@ -595,7 +595,7 @@ class MultiHeadedAttention(torch.nn.Module):
         ):
             causal = self.is_decoder and self.attn_type == "self" and mask is not None
             # flash2 works for decoder only, self (not context)
-            # keeping this (vs sdpa below) only because it handles windows_size (not sure if Mistral will keep this)
+            # keeping this (vs sdpa below) only because it handles windows_size
             if self.is_decoder and self.attn_type == "self" and self.flash:
                 if causal:
                     window_size = (

--- a/eole/tests/test_models.py
+++ b/eole/tests/test_models.py
@@ -31,6 +31,7 @@ class TestModel(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestModel, self).__init__(*args, **kwargs)
         self.opt = opt
+        self.opt.training.self_attn_backend = "pytorch"
 
     def get_vocabs(self):
         src_vocab = pyonmttok.build_vocab_from_tokens(

--- a/recipes/wmt17/wmt17_ende.yaml
+++ b/recipes/wmt17/wmt17_ende.yaml
@@ -63,7 +63,6 @@ training:
 
 model:
     architecture: "transformer"
-    self_attn_type: scaled-dot-flash
     hidden_size: 1024
     share_decoder_embeddings: true
     share_embeddings: true


### PR DESCRIPTION
replace the model setting self_attn_type by a RunningConfig setting self_attn_backend = "flash, pytorch"

In fact:
At training, when using Rotary or Legacy Position Encoding, using flash or pytroch sdpa is almost the same. if alibi or max_relative_positions then it will use "manual" matmul anyway.

At inference: using "flash" instead of "pytorch" will trigger the use of flash_func_with_kvcache which is much faster and not implemented in pytorch 2.3 yet