### PR TITLE
Add support for XLM-Roberta-XL (and XXL) conversion

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -14,7 +14,6 @@ from eole.constants import DefaultTokens
 from eole.config.models import (
     EmbeddingsConfig,
     TransformerEncoderModelConfig,
-    TransformerModelConfig,
     TransformerLMModelConfig,
 )
 from eole.config.run import TrainConfig
@@ -683,7 +682,8 @@ class LlamaHFConverter(BaseBin):
                     1,
                 ):
 
-                    # this is an ugly fix to handle decoder only, encoder only, encoder-decoder models
+                    # this is an ugly fix to handle decoder only, encoder only,
+                    # encoder-decoder models
                     for layer_prefix in [
                         prefix
                         for prefix in [

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -651,8 +651,18 @@ class LlamaHFConverter(BaseBin):
                 for key in weightmap.keys():
                     if (
                         (
-                            key.startswith(key_maps[arch]["decoder_layer_prefix"])
-                            or key.startswith(key_maps[arch]["encoder_layer_prefix"])
+                            (
+                                key_maps[arch]["decoder_layer_prefix"] is not None
+                                and key.startswith(
+                                    key_maps[arch]["decoder_layer_prefix"]
+                                )
+                            )
+                            or (
+                                key_maps[arch]["encoder_layer_prefix"] is not None
+                                and key.startswith(
+                                    key_maps[arch]["encoder_layer_prefix"]
+                                )
+                            )
                         )
                         and int(key.split(".")[2])
                         in range(

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -209,6 +209,7 @@ specials_table = {
     "XLMRobertaXLForMaskedLM": ["<s>", "<blank>", "</s>", "<unk>"],
 }
 
+
 class Tokenizer:
     def __init__(self, model_path: str):
         assert os.path.isfile(model_path), model_path
@@ -573,7 +574,7 @@ class LlamaHFConverter(BaseBin):
 
         decoder_layer_prefix = key_maps[arch].get("decoder_layer_prefix", None)
         encoder_layer_prefix = key_maps[arch].get("encoder_layer_prefix", None)
-        
+
         if wmap_path:
             with open(wmap_path, encoding="utf-8") as fweights:
                 wmap = json.load(fweights)
@@ -660,15 +661,11 @@ class LlamaHFConverter(BaseBin):
                         (
                             (
                                 decoder_layer_prefix is not None
-                                and key.startswith(
-                                    decoder_layer_prefix
-                                )
+                                and key.startswith(decoder_layer_prefix)
                             )
                             or (
                                 encoder_layer_prefix is not None
-                                and key.startswith(
-                                    encoder_layer_prefix
-                                )
+                                and key.startswith(encoder_layer_prefix)
                             )
                         )
                         and int(key.split(".")[2])

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -562,7 +562,8 @@ class LlamaHFConverter(BaseBin):
             position_encoding = {
                 "position_encoding": True,
                 "position_encoding_type": "Learned",
-                "n_positions": 512,
+                "n_positions": 514,
+                "position_shift": 2,
             }
             left_pad = False
             data_task = "encoder"
@@ -855,6 +856,8 @@ class LlamaHFConverter(BaseBin):
             # if shard == 0:
             #     vocab_size = eole_safetensor["generator.weight"].size(0)
             print("Saving output model shard: %d" % shard)
+            for key in eole_safetensor.keys():
+                eole_safetensor[key] = eole_safetensor[key].to(torch.float16)
             save_file(
                 eole_safetensor,
                 os.path.join(args.output, "model.{:02d}.safetensors".format(shard)),

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -299,11 +299,9 @@ class BaseModel(nn.Module):
         # currently in TrainingConfig which makes more sense
         if running_config.freeze_encoder:
             self.encoder.requires_grad_(False)
-            self.src_emb.requires_grad_()
 
         if running_config.freeze_decoder:
             self.decoder.requires_grad_(False)
-            self.tgt_emb.requires_grad_()
 
     @classmethod
     def inference_logic(self, checkpoint, running_config, vocabs, device_id=None):
@@ -400,7 +398,10 @@ class BaseModel(nn.Module):
         model = cls.build_blocks(config, vocabs, running_config=running_config)
         model.maybe_quantize(running_config)
         model.maybe_lora(running_config)
-        model.build_generator(config, vocabs)
+        if config.decoder is not None:
+            model.build_generator(config, vocabs)
+        else:
+            model.generator = None
         return model
 
     @classmethod
@@ -464,6 +465,8 @@ class BaseModel(nn.Module):
         # generator -> shall it be called within build_blocks?
         if model_config.decoder is not None:
             model.build_generator(model_config, vocabs)
+        else:
+            model.generator = None
         # 1 build_base_model
         # quantization stuff
         model.maybe_quantize(
@@ -932,7 +935,7 @@ class EncoderModel(BaseModel):
         mask = sequence_mask(src_len)
         enc_out, enc_final_hs = self.encoder(self.src_emb(src), mask=mask)
         if self.add_estimator:  # on prend en compte les average de enc_out et dec_out
-            pad_mask1 = ~src[:, :, 0].eq(1)
+            pad_mask1 = ~src.eq(1)
             in_estim1 = (enc_out * pad_mask1.unsqueeze(-1).float()).sum(
                 dim=1
             ) / pad_mask1.sum(dim=1, keepdim=True).float()

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -65,6 +65,7 @@ def build_src_emb(model_config, vocabs, running_config=None):
             word_vec_size=model_config.embeddings.src_word_vec_size,
             position_encoding=model_config.embeddings.position_encoding,
             position_encoding_type=model_config.embeddings.position_encoding_type,
+            position_shift=model_config.embeddings.position_shift,
             dropout=getattr(running_config, "dropout", [0.0])[0],
             word_padding_idx=vocabs["src"][DefaultTokens.PAD],
             word_vocab_size=len(vocabs["src"]),
@@ -85,6 +86,7 @@ def build_tgt_emb(
         word_vec_size=model_config.embeddings.tgt_word_vec_size,
         position_encoding=model_config.embeddings.position_encoding,
         position_encoding_type=model_config.embeddings.position_encoding_type,
+        position_shift=model_config.embeddings.position_shift,
         dropout=getattr(running_config, "dropout", [0.0])[0],
         word_padding_idx=vocabs["tgt"][DefaultTokens.PAD],
         word_vocab_size=len(vocabs["tgt"]),
@@ -460,7 +462,8 @@ class BaseModel(nn.Module):
             model_config, vocabs, running_config=running_config
         )  # corresponds to build_task_specific_model
         # generator -> shall it be called within build_blocks?
-        model.build_generator(model_config, vocabs)
+        if model_config.decoder is not None:
+            model.build_generator(model_config, vocabs)
         # 1 build_base_model
         # quantization stuff
         model.maybe_quantize(

--- a/eole/models/model_saver.py
+++ b/eole/models/model_saver.py
@@ -241,9 +241,15 @@ class TrainingModelSaver(ModelSaverBase):
         model_path = os.path.join(
             self.model_path, self.step_dir, "model.00.safetensors"
         )
-        if self.config.model.share_embeddings:
+        if (
+            self.config.model.share_embeddings
+            and "tgt_emb.embeddings.weight" in model_state_dict
+        ):
             model_state_dict.pop("tgt_emb.embeddings.weight")
-        if self.config.model.share_decoder_embeddings:
+        if (
+            self.config.model.share_decoder_embeddings
+            and "generator.weight" in model_state_dict
+        ):
             model_state_dict.pop("generator.weight")
         save_file(model_state_dict, model_path)
         self._make_symlink("model.00.safetensors")

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -97,6 +97,7 @@ class Embeddings(nn.Module):
         word_padding_idx,
         position_encoding=False,
         position_encoding_type="SinusoidalInterleaved",
+        position_shift=0,
         dropout=0,
         sparse=False,
         freeze_word_vecs=False,
@@ -122,6 +123,7 @@ class Embeddings(nn.Module):
 
         self.position_encoding = position_encoding
         self.position_encoding_type = position_encoding_type
+        self.position_shift = position_shift
 
         if self.position_encoding_type == PositionEncodingType.Learned:
             self.pe = nn.Embedding(n_positions, word_vec_size)
@@ -174,7 +176,7 @@ class Embeddings(nn.Module):
                 dtype=torch.long,
                 device=source.device,
             )
-            position_ids = position_ids.unsqueeze(0)
+            position_ids = position_ids.unsqueeze(0) + self.position_shift
             position_emb = self.pe(position_ids)
             emb += position_emb
             if self.past_length == 0:

--- a/eole/train_single.py
+++ b/eole/train_single.py
@@ -200,7 +200,6 @@ def main(config, device_id):
 
     # Build optimizer.
     optim = Optimizer.from_config(model, config, checkpoint=checkpoint)
-
     del checkpoint
 
     # Build model saver

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -548,7 +548,7 @@ class Trainer(object):
                         raise exc
 
                 # If truncated, don't backprop fully.
-                if hasattr(self.model, "decoder") and self.model.decoder.state != {}:
+                if self.model.decoder is not None and self.model.decoder.state != {}:
                     self.model.decoder.detach_state()
 
         # in case of multi step gradient accumulation,

--- a/eole/utils/loss.py
+++ b/eole/utils/loss.py
@@ -76,18 +76,18 @@ class LossCompute(nn.Module):
         )
         padding_idx = vocab[DefaultTokens.PAD]
 
-        if (
-            config.model.decoder is not None
-            and config.model.decoder.lambda_coverage != 0
-        ):
-            lambda_coverage = config.model.decoder.lambda_coverage
-            lambda_align = (
-                getattr(config.model.decoder, "lambda_align", 0.0),
+        if config.model.decoder is not None:
+            lambda_align = getattr(
+                config.model.decoder, "lambda_align", 0.0
             )  # patch to support non transformer configs
-            assert config.model.decoder.coverage_attn, (
-                "--coverage_attn needs to be set in "
-                "order to use --lambda_coverage != 0"
-            )
+            if config.model.decoder.lambda_coverage != 0:
+                lambda_coverage = config.model.decoder.lambda_coverage
+                assert config.model.decoder.coverage_attn, (
+                    "--coverage_attn needs to be set in "
+                    "order to use --lambda_coverage != 0"
+                )
+            else:
+                lambda_coverage = 0
         else:
             lambda_coverage = 0
             lambda_align = 0.0
@@ -307,6 +307,7 @@ class LossCompute(nn.Module):
             loss = torch.tensor([0.0], device=output.device)
             scores = None
 
+        print(self.lambda_align)
         if self.lambda_align != 0.0:
             align_head = attns["align"]
             if align_head.dtype != loss.dtype:  # Fix FP16

--- a/eole/utils/loss.py
+++ b/eole/utils/loss.py
@@ -307,7 +307,6 @@ class LossCompute(nn.Module):
             loss = torch.tensor([0.0], device=output.device)
             scores = None
 
-        print(self.lambda_align)
         if self.lambda_align != 0.0:
             align_head = attns["align"]
             if align_head.dtype != loss.dtype:  # Fix FP16

--- a/eole/utils/optimizers.py
+++ b/eole/utils/optimizers.py
@@ -84,13 +84,22 @@ def build_torch_optimizer(model, config):
         if config.apex_opt_level in ["O0", "O1", "O2", "O3"]:
             # we use apex.amp
             loss_scale = "dynamic" if config.loss_scale == 0 else config.loss_scale
-            model, optimizer = apex.amp.initialize(
-                [model, model.generator],
-                optimizer,
-                opt_level=config.apex_opt_level,
-                loss_scale=loss_scale,
-                keep_batchnorm_fp32=None,
-            )
+            if hasattr(model, "generator") and model.generator is not None:
+                model, optimizer = apex.amp.initialize(
+                    [model, model.generator],
+                    optimizer,
+                    opt_level=config.apex_opt_level,
+                    loss_scale=loss_scale,
+                    keep_batchnorm_fp32=None,
+                )
+            else:
+                model, optimizer = apex.amp.initialize(
+                    model,
+                    optimizer,
+                    opt_level=config.apex_opt_level,
+                    loss_scale=loss_scale,
+                    keep_batchnorm_fp32=None,
+                )
         else:
             if config.model_dtype == "fp16":
                 # In this case use the old FusedAdam with


### PR DESCRIPTION
This is not a full support for xlm-roberta-xl.
The goal is to support the encoder part (not the lm_head / masking / classification) to add the estimator and build a comet-like model.
As is, the encoder output is the same as the hugging face model/code.

@funboarder13920 this breaks even more #26 