### PR TITLE
Some improvements to config.json readability

### DIFF
--- a/eole/config/__init__.py
+++ b/eole/config/__init__.py
@@ -1,4 +1,5 @@
 import os
+from collections import OrderedDict
 from pydantic import Field
 from eole.config.config import Config
 from eole.utils.logging import logger
@@ -7,6 +8,47 @@ from eole.utils.logging import logger
 # default EOLE_MODEL_DIR
 if os.environ.get("EOLE_MODEL_DIR", None) is None:
     os.environ["EOLE_MODEL_DIR"] = os.getcwd()
+
+
+def calculate_depth(value, current_depth=0):
+    if isinstance(value, (dict, Config)):
+        if isinstance(value, Config):
+            value = value.__dict__
+        return (
+            max(calculate_depth(v, current_depth + 1) for v in value.values())
+            if value
+            else current_depth
+        )
+    return current_depth
+
+
+def reorder_fields(fields):
+    """
+    Put non nested fields before nested ones in config json dump,
+    for better readability.
+    """
+    ordered_fields = OrderedDict()
+    non_nested_fields = []
+    nested_fields = []
+
+    for field, value in fields.items():
+        if isinstance(value, dict):
+            nested_fields.append((field, value))
+        else:
+            non_nested_fields.append((field, value))
+
+    # Add non-nested fields first
+    for field, value in non_nested_fields:
+        ordered_fields[field] = value
+
+    # Calculate depths and sort nested fields
+    nested_fields.sort(key=lambda x: calculate_depth(x[1]))
+
+    # Add nested fields
+    for field, value in nested_fields:
+        ordered_fields[field] = reorder_fields(value)
+
+    return ordered_fields
 
 
 def recursive_model_fields_set(model):
@@ -31,10 +73,12 @@ def recursive_model_fields_set(model):
         else:
             field_value = getattr(model, field, None)
         if isinstance(field_value, Config) or isinstance(field_value, dict):
-            fields[field] = recursive_model_fields_set(field_value)
+            _fields = recursive_model_fields_set(field_value)
+            if _fields != {}:
+                fields[field] = _fields
         else:
             fields[field] = field_value
-    return fields
+    return reorder_fields(fields)
 
 
 def recursive_update_dict(_dict, new_dict, defaults):


### PR DESCRIPTION
These are minimal changes to improve dumped config readability:
- prevent dumping empty transforms_configs (change taken from #42);
- dump "non-nested" fields before nested ones, not much but prevents having interspersed items that are difficult to spot;

Example with llama3 convert:

Before
```json
{
  "n_sample": 0,
  "training": {
    "accum_count": [
      32
    ],
    "w_bit": 0,
    "valid_batch_size": 256,
    "batch_size": 896,
    "model_dtype": "fp16",
    "batch_size_multiple": 1,
    "normalization": "tokens",
    "quant_layers": [],
    "quant_type": "",
    "group_size": 0,
    "accum_steps": [
      0
    ],
    "optim": "fusedadam",
    "batch_type": "tokens"
  },
  "decoder_start_token": "<s>",
  "src_vocab": null,
  "tgt_vocab": null,
  "skip_empty_level": "silent",
  "model": {
    "add_ffnbias": false,
    "architecture": "transformer_lm",
    "add_qkvbias": false,
    "num_experts": 0,
    "heads": 32,
    "embeddings": {
      "src_word_vec_size": 4096,
      "tgt_word_vec_size": 4096
    },
    "mlp_activation_fn": "gated-silu",
    "rotary_interleave": false,
    "left_pad": true,
    "model_type": "text",
    "rotary_theta": 500000,
    "sliding_window": 0,
    "layer_norm": "rms",
    "layers": 32,
    "rotary_dim": 0,
    "num_experts_per_tok": 0,
    "parallel_residual": false,
    "decoder": {
      "decoder_type": "transformer_lm",
      "tgt_word_vec_size": 4096
    },
    "shared_layer_norm": false,
    "heads_kv": 8,
    "hidden_size": 4096,
    "transformer_ff": 14336,
    "norm_eps": 1e-05,
    "max_relative_positions": -1
  },
  "transforms_configs": {
    "filtertoolong": {
      "src_seq_length": 512,
      "tgt_seq_length": 512
    }
  },
  "vocab_size_multiple": 8,
  "share_vocab": true,
  "save_data": null,
  "data": null,
  "src_vocab_size": 128256,
  "transforms": [
    "filtertoolong"
  ],
  "data_task": "lm",
  "tgt_vocab_size": 128256
}
```

After
```json
{
  "transforms": [
    "filtertoolong"
  ],
  "src_vocab_size": 128256,
  "decoder_start_token": "<s>",
  "share_vocab": true,
  "vocab_size_multiple": 8,
  "save_data": null,
  "skip_empty_level": "silent",
  "data": null,
  "tgt_vocab": null,
  "tgt_vocab_size": 128256,
  "n_sample": 0,
  "src_vocab": null,
  "training": {
    "group_size": 0,
    "w_bit": 0,
    "quant_layers": [],
    "valid_batch_size": 256,
    "accum_steps": [
      0
    ],
    "normalization": "tokens",
    "model_dtype": "fp16",
    "batch_size": 896,
    "quant_type": "",
    "batch_type": "tokens",
    "accum_count": [
      32
    ],
    "batch_size_multiple": 1,
    "optim": "fusedadam"
  },
  "transforms_configs": {
    "filtertoolong": {
      "tgt_seq_length": 512,
      "src_seq_length": 512
    }
  },
  "model": {
    "heads_kv": 8,
    "architecture": "transformer_lm",
    "rotary_theta": 500000,
    "mlp_activation_fn": "gated-silu",
    "left_pad": true,
    "parallel_residual": false,
    "hidden_size": 4096,
    "layer_norm": "rms",
    "norm_eps": 1e-05,
    "add_ffnbias": false,
    "sliding_window": 0,
    "transformer_ff": 14336,
    "layers": 32,
    "rotary_dim": 0,
    "rotary_interleave": false,
    "shared_layer_norm": false,
    "heads": 32,
    "num_experts": 0,
    "add_qkvbias": false,
    "num_experts_per_tok": 0,
    "max_relative_positions": -1,
    "embeddings": {
      "src_word_vec_size": 4096,
      "tgt_word_vec_size": 4096
    },
    "decoder": {
      "decoder_type": "transformer_lm",
      "tgt_word_vec_size": 4096
    }
  }
}
```