### PR TITLE
[fix] Allow to build_vocab with full train config, patch vocab validation

### DIFF
--- a/eole/bin/run/build_vocab.py
+++ b/eole/bin/run/build_vocab.py
@@ -122,8 +122,8 @@ def build_vocab(config, transforms, n_sample=3):
         ]
         for c_name in corpora.keys()
     }
-    sample_path = os.path.join(os.path.dirname(config.save_data), CorpusName.SAMPLE)
     if config.dump_samples:
+        sample_path = os.path.join(os.path.dirname(config.save_data), CorpusName.SAMPLE)
         write_process = mp.Process(
             target=write_files_from_queues, args=(sample_path, queues), daemon=True
         )

--- a/eole/bin/run/train.py
+++ b/eole/bin/run/train.py
@@ -20,6 +20,7 @@ from eole.bin.run import RunBin
 
 def train(config):
     # config is the full TrainConfig namespace here
+    config._validate_vocab_config()
     init_logger(config.log_file)
     set_random_seed(config.seed, False)
 

--- a/eole/config/config.py
+++ b/eole/config/config.py
@@ -1,6 +1,16 @@
 from pydantic import BaseModel, ConfigDict  # , Enum
 
 
+def get_config_dict():
+    return ConfigDict(
+        validate_assignment=True,
+        validate_default=True,
+        use_enum_values=True,
+        extra="forbid",
+        protected_namespaces=(),  # prevents warning for model_type
+    )
+
+
 class Config(BaseModel):
     """
     All config classes will inherit from this.
@@ -8,13 +18,7 @@ class Config(BaseModel):
     and clarifies a bit naming standards (pydantic model_config vs our own).
     """
 
-    model_config = ConfigDict(
-        validate_assignment=True,
-        validate_default=True,
-        use_enum_values=True,
-        extra="forbid",
-    )
-    model_config["protected_namespaces"] = ()  # prevents warning for model_type
+    model_config = get_config_dict()
 
     def update(self, **kwargs):
         self.__class__.validate(self.__dict__ | kwargs)

--- a/eole/config/data.py
+++ b/eole/config/data.py
@@ -298,11 +298,6 @@ class DataConfig(VocabConfig):  # , AllTransformsConfig):
 
     @model_validator(mode="after")
     def _validate_data_config(self, build_vocab_only=False):
-        if self.n_sample != 0:
-            assert (
-                self.save_data
-            ), "-save_data should be set if \
-                want save samples."
         if self.data is not None:  # patch to allow None data
             self._validate_data()
         self._get_all_transform()

--- a/eole/config/data.py
+++ b/eole/config/data.py
@@ -221,8 +221,11 @@ class DataConfig(VocabConfig):  # , AllTransformsConfig):
     @staticmethod
     def _validate_file(file_path, info):
         """Check `file_path` is valid or raise `IOError`."""
-        if not os.path.isfile(file_path):
-            raise IOError(f"Please check path of your {info} file!")
+        if file_path == "dummy":
+            # hack to allow creating objects with required fields
+            pass
+        elif not os.path.isfile(file_path):
+            raise IOError(f"Please check path of your {info} file! ({file_path})")
 
     def _validate_data(self):
         """Parse corpora specified in data field of YAML file."""
@@ -301,6 +304,7 @@ class DataConfig(VocabConfig):  # , AllTransformsConfig):
         if self.data is not None:  # patch to allow None data
             self._validate_data()
         self._get_all_transform()
-        # not sure about validate_vocab_opts (especially for "build_vocab_only" case)
-        self._validate_vocab_config(build_vocab_only=build_vocab_only)
+        # this is manually triggered where needed, to allow instanciation of
+        # TrainConfig without existing files (e.g. inference)
+        # self._validate_vocab_config(build_vocab_only=build_vocab_only)
         return self

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -341,6 +341,9 @@ class BaseModelConfig(Config):
         default=-1,
         description="Size of hidden states. Overwrites [encoder/decoder].hidden_size if set.",
     )
+    word_vec_size: int = Field(
+        default=-1, description="Word embedding size for src and tgt."
+    )
     layers: int = Field(
         default=-1,
         description="Number of layers in both encoder and decoder "

--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Any
 
+from eole.config.config import get_config_dict
 from eole.config.training import TrainingConfig
 from eole.config.inference import InferenceConfig
 from eole.config.common import MiscConfig, LoggingConfig
@@ -74,6 +75,11 @@ class TrainConfig(
                 "You should either finetune from an existing model, "
                 "or specify a model configuration."
             )
+        if self.n_sample != 0:
+            assert (
+                self.save_data
+            ), "-save_data should be set if \
+                want save samples."
         return self
 
 
@@ -104,6 +110,9 @@ class PredictConfig(
 class BuildVocabConfig(
     DataConfig, MiscConfig, BaseVocabConfig
 ):  # , AllTransformsConfig):
+
+    model_config = get_config_dict()
+    model_config["extra"] = "ignore"
 
     # some specific items related to build_vocab_only flag
     dump_samples: bool = Field(


### PR DESCRIPTION
By default, all configs are set with `extra="allow"``. To facilitate building the vocab with a full train config, e.g. in `wiki_103` or `wmt17`, we'll be more permissive for `BuildVocabConfig`.

Note: pydantic 2.8.0 upgrade triggers errors that were not raised before. This outlined some remaining issues around some vocab/data validation logic. This PR provides some patches, but this logic might be reviewed more in depth at some point.
Also, some unit tests are weirdly failing because of the "dummy" src_vocab path, not sure why it did not fail before. Switched from "dummy" to a real path to fix.