### PR TITLE
Refactor position encoding configuration

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,7 +66,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
           -report_every 5\
           -tensorboard \
@@ -80,7 +80,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 5 \
           -tensorboard \
@@ -96,7 +96,7 @@ jobs:
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
           -report_every 5 \
-          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}, "decoder": {"coverage_attn": True, "lambda_coverage": 0.1}}' \
+          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}, "decoder": {"coverage_attn": True, "lambda_coverage": 0.1}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}'
     - name: Test Transformer training with align
       run: |
@@ -117,7 +117,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding": True}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2}}' \
+          -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding_type": "SinusoidalInterleaved"}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5, "accum_count": [2, 4, 8], "accum_steps": [0, 3, 7], "model_path": "/tmp/eole.model"}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
@@ -338,7 +338,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+          -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "model_path": "/tmp/eole.model", "save_checkpoint_steps": 10}' \
           -report_every 5
         sed -i '1s/^/new_tok\t100000000\n/' /tmp/eole.vocab.src

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -134,7 +134,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": 8, "embeddings": {"word_vec_size": 16}}' \
+          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Relative", "n_positions": 8}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
@@ -151,7 +151,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -1, "embeddings": {"word_vec_size": 16}}' \
+          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Rotary"}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \
@@ -168,7 +168,7 @@ jobs:
           -tgt_vocab /tmp/eole.vocab.tgt \
           -src_vocab_size 1000 \
           -tgt_vocab_size 1000 \
-          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": -2, "embeddings": {"word_vec_size": 16}}' \
+          -model '{"architecture": "transformer", "layers": 4, "heads": 2, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Alibi"}}' \
           -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
           -report_every 2 \
           -valid_metrics "BLEU" "TER" \

--- a/README.md
+++ b/README.md
@@ -113,16 +113,10 @@ cd ..
 
 #### Flash Attention
 
-As of October 2023, Flash Attention 1 has been integrated into PyTorch v2, but using Flash Attention 2 with v2.3.1 is recommended for sliding window attention support. 
-
-For regular `position_encoding=True` or Rotary with `max_relative_positions=-1`, `eole` will attempt to use an optimized dot-product path. To use [Flash Attention](https://github.com/Dao-AILab/flash-attention#installation-and-features), install it manually:
+To use [Flash Attention](https://github.com/Dao-AILab/flash-attention#installation-and-features), install it manually:
 ```bash
 pip install flash-attn --no-build-isolation
 ```
-
-If Flash Attention 2 is not installed, `F.scaled_dot_product_attention` from PyTorch 2.x will be used.
-
-For `max_relative_positions > 0` or Alibi `max_relative_positions=-2`, `eole` will use legacy code for matrix multiplications. Flash Attention and `F.scaled_dot_product_attention` offer faster performance and better GPU memory efficiency.
 
 #### AWQ
 

--- a/docs/docusaurus_tsx/docs/FAQ/performance.md
+++ b/docs/docusaurus_tsx/docs/FAQ/performance.md
@@ -5,5 +5,4 @@
 * use `vocab_size_multiple` 8
 * Depending on the number of GPU use num_workers 4 (for 1 GPU) or 2 (for multiple GPU)
 * To avoid averaging checkpoints you can use the "during training" average decay system.
-* If you train a transformer we support `max_relative_positions` (use 20) instead of position_encoding. 
 * for very fast inference convert your model to CTranslate2 format.

--- a/docs/docusaurus_tsx/docs/FAQ/position_encoding.md
+++ b/docs/docusaurus_tsx/docs/FAQ/position_encoding.md
@@ -7,9 +7,9 @@ However, even with this, we can use SinusoidalInterleaved (default OpenNMT-py) o
 Do not forget to set also `param_init_glorot: true`
 
 If you prefer to use relative position encoding, we support 3 modes:
-* "Shaw": https://arxiv.org/abs/1803.02155 - you need to set `max_relative_positions: N` where N > 1 (use 16, 20, 32) see paper.
-* "Rope" Rotary Embeddings: https://arxiv.org/abs/2104.09864 - you need to set `max_relative_positions: -1`
-* "Alibi" (used by MPT-7B for example) https://arxiv.org/abs/2108.12409 - you need to set `max_relative_positions: -2`
+* "Shaw": https://arxiv.org/abs/1803.02155 - you need to set `position_encoding_type: 'Relative'` and `n_positions: N` where N > 1 (use 16, 20, 32) see paper.
+* "Rope" Rotary Embeddings: https://arxiv.org/abs/2104.09864 - you need to set `position_encoding_type: 'Rotary'`
+* "Alibi" (used by MPT-7B for example) https://arxiv.org/abs/2108.12409 - you need to set `position_encoding_type: 'Alibi'`
 
 In both cases, it is necessary to set `position_encoding: false`
 

--- a/docs/docusaurus_tsx/docs/FAQ/position_encoding.md
+++ b/docs/docusaurus_tsx/docs/FAQ/position_encoding.md
@@ -2,7 +2,6 @@
 
 The basic feature is absolute position encoding stemming from the original Transformer Paper.
 However, even with this, we can use SinusoidalInterleaved (default OpenNMT-py) or SinusoidalConcat (default Fairseq imported models)
-* `position_encoding: true`
 * `position_encoding_type: 'SinusoidalInterleaved'`
 Do not forget to set also `param_init_glorot: true`
 
@@ -10,8 +9,6 @@ If you prefer to use relative position encoding, we support 3 modes:
 * "Shaw": https://arxiv.org/abs/1803.02155 - you need to set `position_encoding_type: 'Relative'` and `n_positions: N` where N > 1 (use 16, 20, 32) see paper.
 * "Rope" Rotary Embeddings: https://arxiv.org/abs/2104.09864 - you need to set `position_encoding_type: 'Rotary'`
 * "Alibi" (used by MPT-7B for example) https://arxiv.org/abs/2108.12409 - you need to set `position_encoding_type: 'Alibi'`
-
-In both cases, it is necessary to set `position_encoding: false`
 
 In a nutshell, at the time if this writing (v3.1) absolute position encoding is managed in the Embeddings module, whereas
 the relative position encoding is managed directly in the multi-head self-attention module.

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -535,8 +535,11 @@ class LlamaHFConverter(BaseBin):
         add_ffnbias = False
         rotary_interleave = False
         shared_layer_norm = False
-        max_relative_positions = -1
-        position_encoding = {}
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Rotary",
+            "n_positions": 0,
+        }
         left_pad = True
 
         # ALL THESE IF SHOULD BE HANDLED IN MAPPINGS
@@ -551,7 +554,6 @@ class LlamaHFConverter(BaseBin):
             shared_layer_norm = True
             add_qkvbias = True
             add_ffnbias = True
-            max_relative_positions = 0
             position_encoding = {
                 "position_encoding": True,
                 "position_encoding_type": "Learned",
@@ -561,7 +563,6 @@ class LlamaHFConverter(BaseBin):
         if arch == "XLMRobertaXLForMaskedLM":
             add_qkvbias = True
             add_ffnbias = True
-            max_relative_positions = 0
             position_encoding = {
                 "position_encoding": True,
                 "position_encoding_type": "Learned",
@@ -986,7 +987,6 @@ class LlamaHFConverter(BaseBin):
                 layer_norm=layer_norm,
                 norm_eps=norm_eps,
                 mlp_activation_fn=mlp_activation_fn,
-                max_relative_positions=max_relative_positions,
                 rotary_interleave=rotary_interleave,
                 rotary_theta=rope_theta,
                 rotary_dim=rotary_dim,

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -536,7 +536,6 @@ class LlamaHFConverter(BaseBin):
         rotary_interleave = False
         shared_layer_norm = False
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Rotary",
             "n_positions": 0,
         }
@@ -555,7 +554,6 @@ class LlamaHFConverter(BaseBin):
             add_qkvbias = True
             add_ffnbias = True
             position_encoding = {
-                "position_encoding": True,
                 "position_encoding_type": "Learned",
                 "n_positions": 1024,
             }
@@ -564,7 +562,6 @@ class LlamaHFConverter(BaseBin):
             add_qkvbias = True
             add_ffnbias = True
             position_encoding = {
-                "position_encoding": True,
                 "position_encoding_type": "Learned",
                 "n_positions": 514,
                 "position_shift": 2,

--- a/eole/bin/convert/convert_T5.py
+++ b/eole/bin/convert/convert_T5.py
@@ -387,6 +387,12 @@ class T5Converter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Relative",
+            "n_positions": params["relative_attention_max_distance"],
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -411,11 +417,11 @@ class T5Converter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 layer_norm="rms",
                 pos_ffn_activation_fn="gated-gelu",
                 self_attn_type="scaled-dot",
-                max_relative_positions=params["relative_attention_max_distance"],
                 relative_positions_buckets=params["relative_attention_num_buckets"],
                 parallel_residual=False,
                 add_qkvbias=False,

--- a/eole/bin/convert/convert_T5.py
+++ b/eole/bin/convert/convert_T5.py
@@ -388,7 +388,6 @@ class T5Converter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Relative",
             "n_positions": params["relative_attention_max_distance"],
         }

--- a/eole/bin/convert/convert_falcon.py
+++ b/eole/bin/convert/convert_falcon.py
@@ -346,6 +346,12 @@ class FalconConverter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Rotary",
+            "n_positions": 0,
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -370,13 +376,13 @@ class FalconConverter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 # src_word_vec_size=src_word_vec_size,
                 # tgt_word_vec_size=tgt_word_vec_size,
                 model_type="text",
                 pos_ffn_activation_fn="gelu",
                 self_attn_type="scaled-dot",  # not sure if scaled-dot-flash is fine
-                max_relative_positions=-1,
                 num_kv=num_kv,
                 parallel_residual=True,
                 shared_layer_norm=shared_layer,

--- a/eole/bin/convert/convert_falcon.py
+++ b/eole/bin/convert/convert_falcon.py
@@ -347,7 +347,6 @@ class FalconConverter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Rotary",
             "n_positions": 0,
         }

--- a/eole/bin/convert/convert_llama.py
+++ b/eole/bin/convert/convert_llama.py
@@ -339,7 +339,6 @@ class LlamaLegacyConverter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Rotary",
             "n_positions": 0,
         }

--- a/eole/bin/convert/convert_llama.py
+++ b/eole/bin/convert/convert_llama.py
@@ -338,6 +338,12 @@ class LlamaLegacyConverter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Rotary",
+            "n_positions": 0,
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -362,6 +368,7 @@ class LlamaLegacyConverter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 # src_word_vec_size=src_word_vec_size,
                 # tgt_word_vec_size=tgt_word_vec_size,
@@ -369,7 +376,6 @@ class LlamaLegacyConverter(BaseBin):
                 norm_eps=norm_eps,
                 pos_ffn_activation_fn="silu",
                 self_attn_type="scaled-dot",
-                max_relative_positions=-1,
                 rotary_interleave=True,
                 rotary_theta=10000,
                 rotary_dim=0,

--- a/eole/bin/convert/convert_mpt.py
+++ b/eole/bin/convert/convert_mpt.py
@@ -188,6 +188,12 @@ class MPTConverter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Alibi",
+            "n_positions": 0,
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -212,13 +218,13 @@ class MPTConverter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 # src_word_vec_size=src_word_vec_size,
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="standard",
                 pos_ffn_activation_fn="gelu",
                 self_attn_type="scaled-dot",
-                max_relative_positions=-2,
                 parallel_residual=False,
                 add_qkvbias=False,
                 add_ffnbias=False,

--- a/eole/bin/convert/convert_mpt.py
+++ b/eole/bin/convert/convert_mpt.py
@@ -189,7 +189,6 @@ class MPTConverter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Alibi",
             "n_positions": 0,
         }

--- a/eole/bin/convert/convert_redpajama.py
+++ b/eole/bin/convert/convert_redpajama.py
@@ -247,7 +247,6 @@ class RedPajamaConverter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Rotary",
             "n_positions": 0,
         }

--- a/eole/bin/convert/convert_redpajama.py
+++ b/eole/bin/convert/convert_redpajama.py
@@ -246,6 +246,12 @@ class RedPajamaConverter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Rotary",
+            "n_positions": 0,
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -270,13 +276,13 @@ class RedPajamaConverter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 # src_word_vec_size=src_word_vec_size,
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="standard",
                 pos_ffn_activation_fn="gelu",
                 self_attn_type="scaled-dot",
-                max_relative_positions=-1,
                 parallel_residual=False,
                 add_qkvbias=True,
                 add_ffnbias=True,

--- a/eole/bin/convert/convert_xgen.py
+++ b/eole/bin/convert/convert_xgen.py
@@ -204,6 +204,12 @@ class XgenConverter(BaseBin):
             for tok in vocab_dict["src"]:
                 vocabfile.write(tok + "\n")
 
+        position_encoding = {
+            "position_encoding": False,
+            "position_encoding_type": "Rotary",
+            "n_positions": 0,
+        }
+
         config = TrainConfig(
             data=None,
             skip_empty_level="silent",  # default is "warning"
@@ -228,13 +234,13 @@ class XgenConverter(BaseBin):
                 embeddings=EmbeddingsConfig(
                     src_word_vec_size=src_word_vec_size,
                     tgt_word_vec_size=tgt_word_vec_size,
+                    **position_encoding,
                 ),
                 # src_word_vec_size=src_word_vec_size,
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="rms",
                 pos_ffn_activation_fn="silu",
                 self_attn_type="scaled-dot",
-                max_relative_positions=-1,
                 parallel_residual=False,
                 add_qkvbias=False,
                 add_ffnbias=False,

--- a/eole/bin/convert/convert_xgen.py
+++ b/eole/bin/convert/convert_xgen.py
@@ -205,7 +205,6 @@ class XgenConverter(BaseBin):
                 vocabfile.write(tok + "\n")
 
         position_encoding = {
-            "position_encoding": False,
             "position_encoding_type": "Rotary",
             "n_positions": 0,
         }

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -458,7 +458,10 @@ class BaseModelConfig(Config):
                 self.encoder.n_positions = self.embeddings.n_positions
         if self.decoder is not None:
             self.decoder.tgt_word_vec_size = self.embeddings.tgt_word_vec_size
-            if getattr(self.decoder, "decoder_type", None) in ["transformer", "transformer_lm"]:
+            if getattr(self.decoder, "decoder_type", None) in [
+                "transformer",
+                "transformer_lm",
+            ]:
                 self.decoder.position_encoding_type = (
                     self.embeddings.position_encoding_type
                 )

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -458,7 +458,7 @@ class BaseModelConfig(Config):
                 self.encoder.n_positions = self.embeddings.n_positions
         if self.decoder is not None:
             self.decoder.tgt_word_vec_size = self.embeddings.tgt_word_vec_size
-            if getattr(self.decoder, "decoder_type", None) == "transformer":
+            if getattr(self.decoder, "decoder_type", None) in ["transformer", "transformer_lm"]:
                 self.decoder.position_encoding_type = (
                     self.embeddings.position_encoding_type
                 )

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -37,8 +37,11 @@ class EmbeddingsConfig(Config):
     )
     n_positions: int | None = Field(
         default=None,
-        description="Absolute number of positions to learn "
-        "position embeddings on (position_encoding_type: Learned)",
+        description="Two cases"
+        "Case 1: Absolute number of positions to learn "
+        "position embeddings on (position_encoding_type: Learned)"
+        "Case 2: Max Relative Positions"
+        "In the case of position_encoding_type: Relative",
     )
     position_shift: int | None = Field(
         default=0,
@@ -167,14 +170,6 @@ class TransformerConfig(Config):
     transformer_ff: int = Field(
         default=2048, description="Size of hidden transformer feed-forward."
     )
-    max_relative_positions: int = Field(
-        default=0,
-        description="This setting enables relative position encoding. "
-        "We support two types of encoding: "
-        "-1 enables Rotary Embeddings (https://arxiv.org/abs/2104.09864), "
-        "> 0 (e.g. 16 or 32) enables maximum distance between inputs "
-        "in relative positions representations (https://arxiv.org/pdf/1803.02155.pdf)",
-    )
     relative_positions_buckets: int = Field(
         default=0,
         description="Enable relative position bias "
@@ -232,6 +227,19 @@ class TransformerConfig(Config):
     num_experts: int = Field(default=0, description="Number of experts for MoE models.")
     num_experts_per_tok: int = Field(
         default=2, description="Number of experts per token."
+    )
+    # These fields are set at EmbeddingsConfig level but will be copied here to be accessible in MHA
+    position_encoding_type: PositionEncodingType = Field(
+        default=PositionEncodingType.SinusoidalInterleaved,
+        description="Type of positional encoding.",
+    )
+    n_positions: int | None = Field(
+        default=None,
+        description="Two cases"
+        "Case 1: Absolute number of positions to learn "
+        "position embeddings on (position_encoding_type: Learned)"
+        "Case 2: Max Relative Positions"
+        "In the case of position_encoding_type: Relative",
     )
 
 
@@ -443,8 +451,18 @@ class BaseModelConfig(Config):
 
         if self.encoder is not None:
             self.encoder.src_word_vec_size = self.embeddings.src_word_vec_size
+            if getattr(self.encoder, "encoder_type", None) == "transformer":
+                self.encoder.position_encoding_type = (
+                    self.embeddings.position_encoding_type
+                )
+                self.encoder.n_positions = self.embeddings.n_positions
         if self.decoder is not None:
             self.decoder.tgt_word_vec_size = self.embeddings.tgt_word_vec_size
+            if getattr(self.decoder, "decoder_type", None) == "transformer":
+                self.decoder.position_encoding_type = (
+                    self.embeddings.position_encoding_type
+                )
+                self.decoder.n_positions = self.embeddings.n_positions
 
         # causing some weird recursion issue in unit test, to investigate
         # if self.encoder is not None:
@@ -593,6 +611,7 @@ class TransformerModelConfig(TransformerConfig, BaseModelConfig):
 
     @model_validator(mode="after")
     def _validate_transformer(self):
+        """
         if (
             getattr(self.embeddings, "position_encoding", False)
             and self.max_relative_positions != 0
@@ -604,6 +623,7 @@ class TransformerModelConfig(TransformerConfig, BaseModelConfig):
                 " -1 for Rotary, or > 0 for Relative Position Representations"
                 "as in https://arxiv.org/pdf/1803.02155.pdf"
             )
+        """
         return self
 
 
@@ -641,6 +661,7 @@ class TransformerLMModelConfig(TransformerConfig, BaseModelConfig):
     @model_validator(mode="after")
     def _validate_transformer(self):
         # duplicate with TransformerModelConfig, might merge at some point
+        """
         if (
             getattr(self.embeddings, "position_encoding", False)
             and self.max_relative_positions != 0
@@ -652,6 +673,7 @@ class TransformerLMModelConfig(TransformerConfig, BaseModelConfig):
                 " -1 for Rotary, or > 0 for Relative Position Representations"
                 "as in https://arxiv.org/pdf/1803.02155.pdf"
             )
+        """
         return self
 
 

--- a/eole/constants.py
+++ b/eole/constants.py
@@ -50,6 +50,9 @@ class PositionEncodingType(str, Enum):
     SinusoidalInterleaved = "SinusoidalInterleaved"
     SinusoidalConcat = "SinusoidalConcat"
     Learned = "Learned"
+    Relative = "Relative"
+    Rotary = "Rotary"
+    Alibi = "Alibi"
 
 
 class ActivationFunction(str, Enum):

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -58,7 +58,6 @@ def build_src_emb(model_config, vocabs, running_config=None):
     # Build embeddings.
     src_emb = Embeddings(
         word_vec_size=model_config.embeddings.src_word_vec_size,
-        position_encoding=model_config.embeddings.position_encoding,
         position_encoding_type=model_config.embeddings.position_encoding_type,
         position_shift=model_config.embeddings.position_shift,
         dropout=getattr(running_config, "dropout", [0.0])[0],
@@ -77,7 +76,6 @@ def build_tgt_emb(
     # Build embeddings.
     tgt_emb = Embeddings(
         word_vec_size=model_config.embeddings.tgt_word_vec_size,
-        position_encoding=model_config.embeddings.position_encoding,
         position_encoding_type=model_config.embeddings.position_encoding_type,
         position_shift=model_config.embeddings.position_shift,
         dropout=getattr(running_config, "dropout", [0.0])[0],

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -28,7 +28,7 @@ class PositionalEncoding(nn.Module):
                 "Cannot use sin/cos positional encoding with "
                 "odd dim (got dim={:d})".format(dim)
             )
-        if enc_type == "SinusoidalInterleaved":
+        if enc_type == PositionEncodingType.SinusoidalInterleaved:
             pe = torch.zeros(max_len, dim)
             position = torch.arange(0, max_len).unsqueeze(1)
             div_term = torch.exp(
@@ -39,7 +39,7 @@ class PositionalEncoding(nn.Module):
             )
             pe[:, 0::2] = torch.sin(position.float() * div_term)
             pe[:, 1::2] = torch.cos(position.float() * div_term)
-        elif enc_type == "SinusoidalConcat":
+        elif enc_type == PositionEncodingType.SinusoidalConcat:
             half_dim = dim // 2
             pe = math.log(10000) / (half_dim - 1)
             pe = torch.exp(torch.arange(half_dim, dtype=torch.float) * -pe)
@@ -84,10 +84,12 @@ class Embeddings(nn.Module):
         word_vec_size (int): size of the dictionary of embeddings.
         word_vocab_size (int): size of dictionary of embeddings for words.
         word_padding_idx (int): padding index for words in the embeddings.
-        position_encoding (bool): see :class:`~eole.modules.PositionalEncoding`
+        position_encoding_type (str): see :constants:`~eole.constants.PositionEncodingType`
+        position_shift (int): patch int for xlm-roberta-xl
         dropout (float): dropout probability.
         sparse (bool): sparse embbedings default False
         freeze_word_vecs (bool): freeze weights of word vectors.
+        n_positions (int): number of positions for Learned position embeddings
     """
 
     def __init__(
@@ -95,7 +97,6 @@ class Embeddings(nn.Module):
         word_vec_size,
         word_vocab_size,
         word_padding_idx,
-        position_encoding=False,
         position_encoding_type="SinusoidalInterleaved",
         position_shift=0,
         dropout=0,
@@ -121,15 +122,20 @@ class Embeddings(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
         self.dropout_p = dropout
 
-        self.position_encoding = position_encoding
         self.position_encoding_type = position_encoding_type
         self.position_shift = position_shift
 
         if self.position_encoding_type == PositionEncodingType.Learned:
             self.pe = nn.Embedding(n_positions, word_vec_size)
             self.past_length = 0
-        elif self.position_encoding:
+        elif self.position_encoding_type in [
+            PositionEncodingType.SinusoidalInterleaved,
+            PositionEncodingType.SinusoidalConcat,
+        ]:
             self.pe = PositionalEncoding(word_vec_size, position_encoding_type)
+        else:
+            # Rotary, Alibi, Relative are handled in MHA
+            pass
 
         if freeze_word_vecs:
             self.embeddings.weight.requires_grad = False
@@ -183,7 +189,10 @@ class Embeddings(nn.Module):
                 self.past_length += source.size(-1)
             else:
                 self.past_length += 1
-        elif self.position_encoding:
+        elif self.position_encoding_type in [
+            PositionEncodingType.SinusoidalInterleaved,
+            PositionEncodingType.SinusoidalConcat,
+        ]:
             emb = self.pe(emb, step)
 
         if self.dropout_p > 0:

--- a/eole/tests/pull_request_check.sh
+++ b/eole/tests/pull_request_check.sh
@@ -110,7 +110,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
             -report_every 5 \
             -tensorboard \
@@ -127,7 +127,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -report_every 2 \
             -tensorboard \
@@ -146,7 +146,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "lambda_align": 0.05, "alignment_layer": 2, "alignment_heads": 0, "heads": 2}}' \
+            -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 64, "embeddings": {"word_vec_size": 16, "position_encoding_type": None}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "lambda_align": 0.05, "alignment_layer": 2, "alignment_heads": 0, "heads": 2}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
             -report_every 5 \
             >> ${LOG_FILE} 2>&1
@@ -160,7 +160,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}, "decoder": {"coverage_attn": True, "lambda_coverage": 0.1}}' \
+            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}, "decoder": {"coverage_attn": True, "lambda_coverage": 0.1}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10}' \
             -report_every 5 \
             >> ${LOG_FILE} 2>&1
@@ -174,7 +174,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding": True}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2,}}' \
+            -model '{"layers": 4, "hidden_size": 16, "transformer_ff": 16, "embeddings": {"word_vec_size": 16, "position_encoding_type": "SinusoidalInterleaved"}, "encoder": {"encoder_type": "transformer", "heads": 2}, "decoder": {"decoder_type": "transformer", "heads": 2,}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -report_every 2 \
             -valid_metrics "BLEU" "TER" \
@@ -272,7 +272,7 @@ ${PYTHON} eole/bin/main.py train \
             -src_vocab $TMP_OUT_DIR/eole.vocab.src \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 -tgt_vocab_size 1000 \
-            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5}}' \
+            -model '{"architecture": "rnn", "hidden_size": 10, "embeddings": {"word_vec_size": 5, "position_encoding_type": None}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "model_path": "'"$TMP_OUT_DIR"'/eole.model", "save_checkpoint_steps": 10}' \
             -report_every 5 \
             >> ${LOG_FILE} 2>&1

--- a/eole/tests/pull_request_check.sh
+++ b/eole/tests/pull_request_check.sh
@@ -195,7 +195,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "max_relative_positions": 8, "heads": 2, "share_decoder_embeddings": True, "share_embeddings": True, "embeddings": {"word_vec_size": 16}}' \
+            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "share_decoder_embeddings": True, "share_embeddings": True, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Relative", "n_positions": 8}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -valid_metrics "BLEU" "TER" \
             -report_every 2 \
@@ -216,7 +216,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "max_relative_positions": -1, "embeddings": {"word_vec_size": 16}}' \
+            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Rotary"}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -valid_metrics "BLEU" "TER" \
             -report_every 2 \
@@ -237,7 +237,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "max_relative_positions": -2, "embeddings": {"word_vec_size": 16}}' \
+            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Alibi"}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -valid_metrics "BLEU" "TER" \
             -report_every 2 \

--- a/eole/tests/test_embeddings.py
+++ b/eole/tests/test_embeddings.py
@@ -1,5 +1,6 @@
 import unittest
 from eole.modules.embeddings import Embeddings
+from eole.constants import PositionEncodingType
 
 import itertools
 from copy import deepcopy
@@ -16,7 +17,7 @@ class TestEmbeddings(unittest.TestCase):
             word_vec_size=[172],
             word_vocab_size=[319],
             word_padding_idx=[17],
-            position_encoding=[False, True],
+            position_encoding_type=[PositionEncodingType.SinusoidalInterleaved, None],
             dropout=[0, 0.5],
             freeze_word_vecs=[False, True],
         )
@@ -81,7 +82,7 @@ class TestEmbeddings(unittest.TestCase):
                         continue
                     if key.endswith("pe.pe"):
                         # ok: positional encodings shouldn't be trainable
-                        assert init_case["position_encoding"]
+                        assert init_case["position_encoding_type"]
                         continue
                     else:
                         self.fail(
@@ -96,7 +97,7 @@ class TestEmbeddings(unittest.TestCase):
                     ),
                     "Word embedding is trainable but word vecs are freezed.",
                 )
-            if init_case["position_encoding"]:
+            if init_case["position_encoding_type"]:
                 self.assertFalse(
                     any(
                         trainable_p.endswith(".pe.pe")

--- a/eole/tests/test_model.yml
+++ b/eole/tests/test_model.yml
@@ -78,7 +78,6 @@ tgt_vocab_size: 1000
 #  global_attention='general', 
 # global_attention_function='softmax',
 #  self_attn_type='scaled-dot',
-#  max_relative_positions=0,
 #  heads=8,
 #  transformer_ff=2048,
 #  aan_useffn=False, 

--- a/eole/tests/test_model/config.json
+++ b/eole/tests/test_model/config.json
@@ -17,7 +17,8 @@
     "embeddings": {
       "tgt_word_vec_size": 256,
       "src_word_vec_size": 256,
-      "word_vec_size": 256
+      "word_vec_size": 256,
+      "position_encoding_type": null
     }
   },
   "src_vocab": "dummy",

--- a/eole/tests/test_model2/config.json
+++ b/eole/tests/test_model2/config.json
@@ -9,7 +9,8 @@
     "embeddings": {
       "tgt_word_vec_size": 100,
       "src_word_vec_size": 100,
-      "word_vec_size": 100
+      "word_vec_size": 100,
+      "position_encoding_type": null
     },
     "architecture": "custom",
     "encoder": {

--- a/eole/tests/test_model_lm.yml
+++ b/eole/tests/test_model_lm.yml
@@ -135,7 +135,6 @@ share_vocab: true
 # global_attention='general',
 # global_attention_function='softmax',
 # self_attn_type='scaled-dot',
-# max_relative_positions=0,
 # heads=2,
 # transformer_ff=256, 
 # aan_useffn=False,

--- a/eole/tests/test_model_lm/config.json
+++ b/eole/tests/test_model_lm/config.json
@@ -14,7 +14,6 @@
     "encoder": null,
     "embeddings": {
       "tgt_word_vec_size": 64,
-      "position_encoding": true,
       "src_word_vec_size": 64,
       "word_vec_size": 64
     }

--- a/recipes/cometkiwi/cometkiwi-xl-eole.yaml
+++ b/recipes/cometkiwi/cometkiwi-xl-eole.yaml
@@ -131,7 +131,6 @@ model:
     embeddings:
         freeze_word_vecs_enc: true
         word_vec_size: 2560
-        position_encoding: true
         position_encoding_type: Learned
         n_positions: 514
         position_shift: 2

--- a/recipes/cometkiwi/cometkiwi-xl-eole.yaml
+++ b/recipes/cometkiwi/cometkiwi-xl-eole.yaml
@@ -125,7 +125,6 @@ model:
     add_estimator: true
     share_decoder_embeddings: true
     share_embeddings: true
-    max_relative_positions: 0
     rotary_interleave: false
     layer_norm: standard
     norm_eps: 1e-5

--- a/recipes/cometkiwi/cometkiwi-xxl-eole.yaml
+++ b/recipes/cometkiwi/cometkiwi-xxl-eole.yaml
@@ -121,7 +121,6 @@ model:
     #shared_layer_norm: true
     add_estimator: true
     share_decoder_embeddings: true
-    max_relative_positions: 0
     rotary_interleave: false
     layer_norm: standard
     norm_eps: 1e-5

--- a/recipes/cometkiwi/cometkiwi-xxl-eole.yaml
+++ b/recipes/cometkiwi/cometkiwi-xxl-eole.yaml
@@ -127,7 +127,6 @@ model:
     embeddings:
         freeze_word_vecs_enc: true
         word_vec_size: 4096
-        position_encoding: true
         position_encoding_type: Learned
         n_positions: 514
         position_shift: 2

--- a/recipes/wmt17/wmt17_ende.yaml
+++ b/recipes/wmt17/wmt17_ende.yaml
@@ -71,4 +71,4 @@ model:
     transformer_ff: 4096
     embeddings:
         word_vec_size: 1024
-        position_encoding: true
+        position_encoding_type: "SinusoidalInterleaved"


### PR DESCRIPTION
address #17 
Now we need to configure "position_encoding_type" which takes the following values:

class PositionEncodingType(str, Enum):
    SinusoidalInterleaved = "SinusoidalInterleaved"
    SinusoidalConcat = "SinusoidalConcat"
    Learned = "Learned"
    Relative = "Relative"
    Rotary = "Rotary"
    Alibi = "Alibi"
or None

For the first 3 (absolute position encoding) it will be handled at the Embeddings level.

For the last 3 it is handled in the multi-head-attention

By default it is: SinusoidalInterleaved

If you want no encoding then use None (or null in the config.json)
