### PR TITLE
Remove unnecessary optim in convert_HF

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -1029,7 +1029,6 @@ class LlamaHFConverter(BaseBin):
                 quant_type=quant_type,
                 w_bit=w_bit,
                 group_size=group_size,
-                optim="fusedadam",
             ),
         )
         config_dict = recursive_model_fields_set(config)

--- a/eole/bin/convert/convert_T5.py
+++ b/eole/bin/convert/convert_T5.py
@@ -420,7 +420,6 @@ class T5Converter(BaseBin):
                 ),
                 layer_norm="rms",
                 pos_ffn_activation_fn="gated-gelu",
-                self_attn_type="scaled-dot",
                 relative_positions_buckets=params["relative_attention_num_buckets"],
                 parallel_residual=False,
                 add_qkvbias=False,
@@ -437,7 +436,6 @@ class T5Converter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 

--- a/eole/bin/convert/convert_falcon.py
+++ b/eole/bin/convert/convert_falcon.py
@@ -381,7 +381,6 @@ class FalconConverter(BaseBin):
                 # tgt_word_vec_size=tgt_word_vec_size,
                 model_type="text",
                 pos_ffn_activation_fn="gelu",
-                self_attn_type="scaled-dot",  # not sure if scaled-dot-flash is fine
                 num_kv=num_kv,
                 parallel_residual=True,
                 shared_layer_norm=shared_layer,
@@ -397,7 +396,6 @@ class FalconConverter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 

--- a/eole/bin/convert/convert_llama.py
+++ b/eole/bin/convert/convert_llama.py
@@ -374,7 +374,6 @@ class LlamaLegacyConverter(BaseBin):
                 layer_norm="rms",
                 norm_eps=norm_eps,
                 pos_ffn_activation_fn="silu",
-                self_attn_type="scaled-dot",
                 rotary_interleave=True,
                 rotary_theta=10000,
                 rotary_dim=0,
@@ -393,7 +392,6 @@ class LlamaLegacyConverter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 

--- a/eole/bin/convert/convert_mpt.py
+++ b/eole/bin/convert/convert_mpt.py
@@ -223,7 +223,6 @@ class MPTConverter(BaseBin):
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="standard",
                 pos_ffn_activation_fn="gelu",
-                self_attn_type="scaled-dot",
                 parallel_residual=False,
                 add_qkvbias=False,
                 add_ffnbias=False,
@@ -237,7 +236,6 @@ class MPTConverter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 

--- a/eole/bin/convert/convert_redpajama.py
+++ b/eole/bin/convert/convert_redpajama.py
@@ -281,7 +281,6 @@ class RedPajamaConverter(BaseBin):
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="standard",
                 pos_ffn_activation_fn="gelu",
-                self_attn_type="scaled-dot",
                 parallel_residual=False,
                 add_qkvbias=True,
                 add_ffnbias=True,
@@ -295,7 +294,6 @@ class RedPajamaConverter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 

--- a/eole/bin/convert/convert_xgen.py
+++ b/eole/bin/convert/convert_xgen.py
@@ -239,7 +239,6 @@ class XgenConverter(BaseBin):
                 # tgt_word_vec_size=tgt_word_vec_size,
                 layer_norm="rms",
                 pos_ffn_activation_fn="silu",
-                self_attn_type="scaled-dot",
                 parallel_residual=False,
                 add_qkvbias=False,
                 add_ffnbias=False,
@@ -253,7 +252,6 @@ class XgenConverter(BaseBin):
                 accum_count=[32],
                 accum_steps=[0],
                 valid_batch_size=256,
-                optim="fusedadam",
             ),
         )
 


### PR DESCRIPTION
Fix #70 

It is quite unnecessary to set an optim at the conversion stage. It will be eventually configured in the finetuning config anyways.