### PR TITLE
add head_dim setting when diff from hidden // heads

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -448,6 +448,11 @@ class LlamaHFConverter(BaseBin):
         else:
             heads_kv = heads
 
+        if "head_dim" in config.keys():
+            head_dim = config["head_dim"]
+        else:
+            head_dim = None
+
         if "parallel_attn" in config.keys():
             parallel_residual = config["parallel_attn"]
         else:
@@ -1008,6 +1013,7 @@ class LlamaHFConverter(BaseBin):
                 rotary_dim=rotary_dim,
                 sliding_window=sliding_window,
                 heads_kv=heads_kv,
+                head_dim=head_dim,
                 parallel_residual=parallel_residual,
                 shared_layer_norm=shared_layer_norm,
                 add_qkvbias=add_qkvbias,

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -254,7 +254,7 @@ class TransformerConfig(Config):
     @property
     def dim_per_head(self) -> int:
         if self.head_dim is not None:
-           return self.head_dim
+            return self.head_dim
         else:
             return self.hidden_size // self.heads
 

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -219,6 +219,10 @@ class TransformerConfig(Config):
         description="Number of heads for KV. heads_kv=heads if None, else number of heads for KV"
         "(e.g. Falcon 40B)",
     )
+    head_dim: int | None = Field(
+        default=None,
+        description="Head dimension when this needs to be different vs hidden_size // heads",
+    )
     add_ffnbias: bool = Field(
         default=False, description="Add bias to nn.Linear of MLP FFN."
     )

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -3,6 +3,7 @@ from pydantic import (
     Field,
     field_validator,
     model_validator,
+    computed_field,
 )  # , TypeAdapter
 
 from eole.constants import PositionEncodingType, ActivationFunction, ModelType
@@ -248,6 +249,14 @@ class TransformerConfig(Config):
         "Case 2: Max Relative Positions"
         "In the case of position_encoding_type: Relative",
     )
+
+    @computed_field
+    @property
+    def dim_per_head(self) -> int:
+        if self.head_dim is not None:
+           return self.head_dim
+        else:
+            return self.hidden_size // self.heads
 
 
 # could eole.encoders.TransformerEncoder class inherit from this? (it seems not unfortunately)

--- a/eole/modules/multi_headed_attn.py
+++ b/eole/modules/multi_headed_attn.py
@@ -267,16 +267,8 @@ class MultiHeadedAttention(torch.nn.Module):
         running_config=None,
         is_decoder: bool = True,
     ) -> None:
-        if hasattr(model_config, "head_dim"):
-            self.dim_per_head = (
-                model_config.head_dim
-                if model_config.head_dim is not None
-                else model_config.hidden_size // model_config.heads
-            )
-        else:
-            self.dim_per_head = model_config.hidden_size // model_config.heads
-
         super(MultiHeadedAttention, self).__init__()
+        self.dim_per_head = model_config.dim_per_head
         self.heads = model_config.heads
         self.heads_kv = (
             model_config.heads_kv


### PR DESCRIPTION
This is need for MistralNemo

Also these papers refer to a 6/6 layers 16 heads 1024 hidden 8192 ffn BUT with 128 head dim (which is different from 1024//16):
[I had hard time to find out why 551M params for their transformer)
[https://arxiv.org/pdf/2311.05350](https://arxiv.org/pdf/2311.05350)
[https://arxiv.org/pdf/2310.06707](https://arxiv.org/pdf/2310.06707)