### PR TITLE
[fix] fix normalize and clean transforms config management

### DIFF
--- a/eole/config/data.py
+++ b/eole/config/data.py
@@ -87,10 +87,29 @@ class Dataset(Config):
     )
     path_align: str | None = None
     # optional stuff for some transforms
+    # TODO: define a better mechanism to support such settings
     src_prefix: str | None = None
     tgt_prefix: str | None = None
     src_suffix: str | None = None
     tgt_suffix: str | None = None
+    # normalize
+    src_lang: str | None = None
+    tgt_lang: str | None = None
+    penn: bool | None = True
+    norm_quote_commas: bool | None = True
+    norm_numbers: bool | None = True
+    pre_replace_unicode_punct: bool | None = False
+    post_remove_control_chars: bool | None = False
+    # clean
+    src_eq_tgt: bool | None = True
+    same_char: bool | None = True
+    same_word: bool | None = True
+    scripts_ok: List[str] | None = ["Latin", "Common"]
+    scripts_nok: List[str] | None = []
+    src_tgt_ratio: float | None = 2
+    avg_tok_min: float | None = 3
+    avg_tok_max: float | None = 20
+    lang_id: List[str] | None = ["en", "fr"]
 
 
 # add all opts from all transforms (like in eole.opts._add_transform_opt)

--- a/eole/transforms/clean.py
+++ b/eole/transforms/clean.py
@@ -18,6 +18,10 @@ class CleanConfig(TransformConfig):
     )
     scripts_ok: List[str] | None = Field(
         default=["Latin", "Common"],
+        description="list of unicodata scripts accepted",
+    )
+    scripts_nok: List[str] | None = Field(
+        default=[],
         description="list of unicodata scripts not accepted",
     )
     src_tgt_ratio: float | None = Field(
@@ -63,8 +67,8 @@ class CleanTransform(Transform):
     @staticmethod
     def _get_param(corpus, param, def_val):
         """Get param string of a `corpus`."""
-        if "clean" in corpus["transforms"]:
-            value = corpus.get(param, def_val)
+        if "clean" in getattr(corpus, "transforms", []):
+            value = getattr(corpus, param, def_val)
             clean = value
         else:
             clean = None
@@ -88,17 +92,25 @@ class CleanTransform(Transform):
         super().warm_up(None)
         import fasttext
 
-        self.src_eq_tgt_dict = self.get_config_dict(self.config, "src_eq_tgt", True)
-        self.same_char_dict = self.get_config_dict(self.config, "same_char", True)
-        self.same_word_dict = self.get_config_dict(self.config, "same_word", True)
-        self.scripts_ok_dict = self.get_config_dict(
-            self.config, "scripts_ok", ["Latin", "Common"]
+        self.src_eq_tgt_dict = self.get_config_dict(
+            self.full_config, "src_eq_tgt", True
         )
-        self.scripts_nok_dict = self.get_config_dict(self.config, "scripts_nok", [])
-        self.src_tgt_ratio_dict = self.get_config_dict(self.config, "src_tgt_ratio", 2)
-        self.avg_tok_min_dict = self.get_config_dict(self.config, "avg_tok_min", 3)
-        self.avg_tok_max_dict = self.get_config_dict(self.config, "avg_tok_max", 20)
-        self.langid_dict = self.get_config_dict(self.config, "langid", [])
+        self.same_char_dict = self.get_config_dict(self.full_config, "same_char", True)
+        self.same_word_dict = self.get_config_dict(self.full_config, "same_word", True)
+        self.scripts_ok_dict = self.get_config_dict(
+            self.full_config, "scripts_ok", ["Latin", "Common"]
+        )
+        self.scripts_nok_dict = self.get_config_dict(
+            self.full_config, "scripts_nok", []
+        )
+        self.src_tgt_ratio_dict = self.get_config_dict(
+            self.full_config, "src_tgt_ratio", 2
+        )
+        self.avg_tok_min_dict = self.get_config_dict(self.full_config, "avg_tok_min", 3)
+        self.avg_tok_max_dict = self.get_config_dict(
+            self.full_config, "avg_tok_max", 20
+        )
+        self.langid_dict = self.get_config_dict(self.full_config, "langid", [])
         fasttext_loc = f"{os.path.dirname(os.path.abspath(__file__))}/lid.176.ftz"
 
         if not os.path.exists(fasttext_loc):

--- a/eole/transforms/normalize.py
+++ b/eole/transforms/normalize.py
@@ -247,8 +247,8 @@ class NormalizeTransform(Transform):
     @staticmethod
     def _get_param(corpus, param, def_val):
         """Get opt string of a `corpus`."""
-        if "normalize" in corpus["transforms"]:
-            value = corpus.get(param, def_val)
+        if "normalize" in getattr(corpus, "transforms", []):
+            value = getattr(corpus, param, def_val)
             normalize = value
         else:
             normalize = None
@@ -271,18 +271,20 @@ class NormalizeTransform(Transform):
     def warm_up(self, vocabs=None):
         """Set options for each dataset."""
         super().warm_up(None)
-        self.src_lang_dict = self.get_config_dict(self.config, "src_lang", "")
-        self.tgt_lang_dict = self.get_config_dict(self.config, "tgt_lang", "")
-        self.penn_dict = self.get_config_dict(self.config, "penn", True)
+        self.src_lang_dict = self.get_config_dict(self.full_config, "src_lang", "")
+        self.tgt_lang_dict = self.get_config_dict(self.full_config, "tgt_lang", "")
+        self.penn_dict = self.get_config_dict(self.full_config, "penn", True)
         self.norm_quote_commas_dict = self.get_config_dict(
-            self.config, "norm_quote_commas", True
+            self.full_config, "norm_quote_commas", True
         )
-        self.norm_numbers_dict = self.get_config_dict(self.config, "norm_numbers", True)
+        self.norm_numbers_dict = self.get_config_dict(
+            self.full_config, "norm_numbers", True
+        )
         self.pre_dict = self.get_config_dict(
-            self.config, "pre_replace_unicode_punct", False
+            self.full_config, "pre_replace_unicode_punct", False
         )
         self.post_dict = self.get_config_dict(
-            self.config, "post_remove_control_chars", False
+            self.full_config, "post_remove_control_chars", False
         )
         self.src_lang_dict["infer"] = self.src_lang
         self.tgt_lang_dict["infer"] = self.tgt_lang


### PR DESCRIPTION
Fix #83 

These transforms rely on a some dataset-level configuration which was not properly implemented in the major refactor.
This PR makes it work, but we should ideally find some cleaner way to handle such settings (which are currently duplicated across some TransformConfig subclasses and the Dataset config class).