### PR TITLE
Fixed variable referenced before assignment when position_embeddings is None error

### DIFF
--- a/eole/modules/multi_headed_attn.py
+++ b/eole/modules/multi_headed_attn.py
@@ -670,6 +670,9 @@ class SelfMHA(MultiHeadedAttention):
                         .imag.contiguous()
                         .half()
                     )
+                else:
+                    cos = None
+                    sin = None
                 context = self.flash_attn_with_kvcache(
                     query.transpose(1, 2),
                     self.layer_cache[1]["keys"].transpose(1, 2),


### PR DESCRIPTION
The recent Multi Headed Attention and RoPE refactoring resulting in the following error when position_embeddings is None (i.e. not using RoPE):

```
File "/workspace/eole/eole/modules/multi_headed_attn.py", line 679, in forward [1100/1801]
rotary_cos=cos,
UnboundLocalError: local variable 'cos' referenced before assignment
```