### PR TITLE
Send src_pad_mask and tgt_pad_mask to decoder in _align_forward

### DIFF
--- a/eole/predict/translator.py
+++ b/eole/predict/translator.py
@@ -64,7 +64,7 @@ class Translator(Inference):
             enc_out=enc_out,
             src_pad_mask=src_pad_mask,
             tgt_pad_mask=tgt_pad_mask,
-            with_align=True
+            with_align=True,
         )
 
         alignment_attn = attns["align"]  # ``(B, tgt_len-1, src_len)``


### PR DESCRIPTION
Fixes assertion error when using _--report_align_ by passing _src_pad_mask_ and _tgt_pad_mask_ to decoder
```
  File "~/eole/eole/decoders/transformer_decoder.py", line 180, in forward
    assert tgt_pad_mask is not None, "TransformerDecoder requires a tgt pad mask"
AssertionError: TransformerDecoder requires a tgt pad mask
```