### PR TITLE
Support mapped tokens eg: <im_start> ==> ｟im_start｠in inference.yaml …

### DIFF
--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -99,6 +99,10 @@ class PredictConfig(
         None  # patch for CT2 inference engine (to improve later)
     )
     model: ModelConfig | None = None
+    optional_eos: List[str] | None = Field(
+        default=[],
+        description="Optional EOS tokens that would stop generation, e.g. <|eot_id|> for Llama3",
+    )
 
     @model_validator(mode="after")
     def _validate_predict_config(self):

--- a/eole/predict/beam_search.py
+++ b/eole/predict/beam_search.py
@@ -382,7 +382,7 @@ class BeamSearchBase(DecodeStrategy):
             )
             self.topk_scores -= cov_penalty.view(_B, self.beam_size).float()
 
-        self.is_finished_list = self.topk_ids.eq(self.eos).tolist()
+        self.is_finished_list = torch.isin(self.topk_ids, self.eos_t).tolist()
 
         self.ensure_max_length()
 
@@ -403,6 +403,7 @@ class BeamSearch(BeamSearchBase):
         if device is None:
             device = self.get_device_from_enc_out(enc_out)
 
+        self.eos_t = torch.tensor(self.eos).to(device)
         super(BeamSearch, self).initialize_(enc_out, device, target_prefix)
 
         return fn_map_state, enc_out
@@ -423,6 +424,7 @@ class BeamSearchLM(BeamSearchBase):
         if device is None:
             device = src.device
 
+        self.eos_t = torch.tensor(self.eos).to(device)
         super(BeamSearchLM, self).initialize_(
             None,
             device=device,

--- a/eole/predict/decode_strategy.py
+++ b/eole/predict/decode_strategy.py
@@ -85,7 +85,10 @@ class DecodeStrategy(object):
         # magic indices
         self.pad = pad
         self.bos = bos
-        self.eos = eos
+        if isinstance(eos, int):
+            self.eos = [eos]
+        else:
+            self.eos = eos
         self.unk = unk
         self.start = start
 
@@ -180,7 +183,8 @@ class DecodeStrategy(object):
 
     def ensure_min_length(self, log_probs):
         if len(self) <= self.min_length:
-            log_probs[:, self.eos] = -65504  # -1e20
+            for eos in self.eos:
+                log_probs[:, eos] = -65504  # -1e20
 
     def ensure_unk_removed(self, log_probs):
         if self.ban_unk_token:
@@ -278,12 +282,12 @@ class DecodeStrategy(object):
             pick_coo = [
                 [path_i, pick]
                 for path_i, pick in enumerate(pick_idx)
-                if pick not in [self.eos, self.pad]
+                if pick not in [*self.eos, self.pad]
             ]
             mask_pathid = [
                 path_i
                 for path_i, pick in enumerate(pick_idx)
-                if pick in [self.eos, self.pad]
+                if pick in [*self.eos, self.pad]
             ]
             if len(pick_coo) > 0:
                 pick_coo = torch.tensor(pick_coo).to(self.target_prefix)

--- a/eole/predict/greedy_search.py
+++ b/eole/predict/greedy_search.py
@@ -235,7 +235,7 @@ class GreedySearch(DecodeStrategy):
         topk_ids, self.topk_scores = self._pick(log_probs)
         self.beams_scores += self.topk_scores
 
-        self.is_finished_list = topk_ids.eq(self.eos).tolist()
+        self.is_finished_list = torch.isin(topk_ids, self.eos_t).tolist()
 
         self.alive_seq = torch.cat([self.alive_seq, topk_ids], -1)
         if self.return_attention:
@@ -301,7 +301,7 @@ class GreedySearchLM(GreedySearch):
 
         if device is None:
             device = src.device
-
+        self.eos_t = torch.tensor(self.eos).to(device)
         (fn_map_state, _) = super(GreedySearchLM, self).initialize(
             None, src_len, device, target_prefix
         )

--- a/eole/predict/greedy_search.py
+++ b/eole/predict/greedy_search.py
@@ -171,6 +171,7 @@ class GreedySearch(DecodeStrategy):
         if device is None:
             device = self.get_device_from_enc_out(enc_out)
 
+        self.eos_t = torch.tensor(self.eos).to(device)
         super(GreedySearch, self).initialize(device, target_prefix)
         self.select_indices = torch.arange(
             self.batch_size * self.beam_size, dtype=torch.long, device=device

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -86,11 +86,14 @@ class Inference(object):
         with_score=False,
         return_gold_log_probs=False,
         add_estimator=False,
+        optional_eos=[],
     ):
         self.model = model
         self.vocabs = vocabs
         self._tgt_vocab = vocabs["tgt"]
-        self._tgt_eos_idx = vocabs["tgt"].lookup_token(DefaultTokens.EOS)
+        self._tgt_eos_idx = [vocabs["tgt"].lookup_token(DefaultTokens.EOS)] + [
+            vocabs["tgt"].lookup_token(tok) for tok in optional_eos
+        ]
         self._tgt_pad_idx = vocabs["tgt"].lookup_token(DefaultTokens.PAD)
         self._tgt_bos_idx = vocabs["tgt"].lookup_token(DefaultTokens.BOS)
         self._tgt_unk_idx = vocabs["tgt"].lookup_token(DefaultTokens.UNK)
@@ -224,6 +227,7 @@ class Inference(object):
             seed=config.seed,
             with_score=config.with_score,
             add_estimator=model_config.add_estimator,
+            optional_eos=config.optional_eos,
         )
 
     def _log(self, msg):
@@ -275,6 +279,7 @@ class Inference(object):
             self.n_best,
             self.replace_unk,
             self.phrase_table,
+            self._tgt_eos_idx,
         )
 
         # Statistics

--- a/eole/predict/prediction.py
+++ b/eole/predict/prediction.py
@@ -19,11 +19,14 @@ class PredictionBuilder(object):
        replace_unk (bool): replace unknown words using attention
     """
 
-    def __init__(self, vocabs, n_best=1, replace_unk=False, phrase_table=""):
+    def __init__(
+        self, vocabs, n_best=1, replace_unk=False, phrase_table="", tgt_eos_idx=None
+    ):
         self.vocabs = vocabs
         self.n_best = n_best
         self.replace_unk = replace_unk
         self.phrase_table_dict = {}
+        self.tgt_eos_idx = tgt_eos_idx  # List of IDs here
         if phrase_table != "" and os.path.exists(phrase_table):
             with open(phrase_table) as phrase_table_fd:
                 for line in phrase_table_fd:
@@ -33,17 +36,18 @@ class PredictionBuilder(object):
                     self.phrase_table_dict[phrase_src] = phrase_trg
 
     def _build_target_tokens(self, src, srclen, pred, attn, voc, dyn_voc):
+        pred_list = pred.tolist()
+        if pred_list[-1] in self.tgt_eos_idx:
+            pred_list = pred_list[:-1]
         if dyn_voc is None:
-            tokens = [voc[tok] for tok in pred.tolist()]
+            tokens = [voc[tok] for tok in pred_list]
         else:
             tokens = [
                 voc[tok]
                 if tok < len(voc)
                 else dyn_voc.ids_to_tokens[tok - len(self.vocabs["src"].ids_to_tokens)]
-                for tok in pred.tolist()
+                for tok in pred_list
             ]
-        if tokens[-1] == DefaultTokens.EOS:
-            tokens = tokens[:-1]
 
         if self.replace_unk and attn is not None and src is not None:
             for i in range(len(tokens)):

--- a/eole/transforms/tokenize.py
+++ b/eole/transforms/tokenize.py
@@ -4,7 +4,7 @@ from eole.utils.logging import logger
 from eole.transforms import register_transform
 from .transform import Transform, ObservableStats, TransformConfig
 from eole.constants import DefaultTokens
-from typing import Literal
+from typing import Literal, List, Tuple
 from pydantic import model_validator, Field
 
 
@@ -91,6 +91,10 @@ class ONMTTokenizerConfig(BaseTokenizerConfig):
     )
     gpt2_pretok: bool | None = Field(
         default=False, description="Preprocess sentence with byte-level mapping."
+    )
+    mapped_tokens: List[Tuple[str, str]] | None = Field(
+        default=None,
+        description="Mapped tokens for placeholders preservation",
     )
 
     @model_validator(mode="after")
@@ -388,6 +392,7 @@ class ONMTTokenizerTransform(TokenizerTransform):
         self.src_other_kwargs = self.config.src_onmttok_kwargs
         self.tgt_other_kwargs = self.config.tgt_onmttok_kwargs
         self.gpt2_pretok = self.config.gpt2_pretok
+        self.mapped_tokens = self.config.mapped_tokens
         self.preserve_placeholders = self.config.tgt_onmttok_kwargs.get(
             "preserve_placeholders", False
         )
@@ -496,11 +501,16 @@ class ONMTTokenizerTransform(TokenizerTransform):
 
     def tokenize_string(self, sentence, side="src", is_train=False):
         tokenizer = self.load_models[side]
+
+        for mapped_toks in self.mapped_tokens:
+            sentence = sentence.replace(mapped_toks[0], mapped_toks[1])
+
         if self.gpt2_pretok:
             sentence = "".join(
                 self.maptable[b]
                 for b in sentence.replace(DefaultTokens.SEP, "\n").encode("utf-8")
             )
+            sentence = sentence.replace("ï½Ł", "\uff5f").replace("ï½ł", "\uff60")
             segmented1 = tokenizer(sentence)
             segmented = []
             # ugly patch to make sure "\n\n" is split in two items
@@ -510,12 +520,16 @@ class ONMTTokenizerTransform(TokenizerTransform):
                 else:
                     segmented.append(s)
         elif (
-            self.src_subword_type == "sentencepiece" and not self.preserve_placeholders
+            self.src_subword_type
+            == "sentencepiece"  # and not self.preserve_placeholders
         ):
             sentence = sentence.replace(DefaultTokens.SEP, "\n")
             segmented = tokenizer(sentence)
         else:
             segmented = tokenizer(sentence)
+
+        mapped_dict = {b: a for a, b in self.mapped_tokens}
+        segmented = [mapped_dict.get(tok, tok) for tok in segmented]
         return segmented
 
     def _detokenize(self, tokens, side="src", is_train=False):

--- a/eole/transforms/tokenize.py
+++ b/eole/transforms/tokenize.py
@@ -502,8 +502,9 @@ class ONMTTokenizerTransform(TokenizerTransform):
     def tokenize_string(self, sentence, side="src", is_train=False):
         tokenizer = self.load_models[side]
 
-        for mapped_toks in self.mapped_tokens:
-            sentence = sentence.replace(mapped_toks[0], mapped_toks[1])
+        if self.mapped_tokens is not None:
+            for mapped_toks in self.mapped_tokens:
+                sentence = sentence.replace(mapped_toks[0], mapped_toks[1])
 
         if self.gpt2_pretok:
             sentence = "".join(
@@ -528,8 +529,9 @@ class ONMTTokenizerTransform(TokenizerTransform):
         else:
             segmented = tokenizer(sentence)
 
-        mapped_dict = {b: a for a, b in self.mapped_tokens}
-        segmented = [mapped_dict.get(tok, tok) for tok in segmented]
+        if self.mapped_tokens is not None:
+            mapped_dict = {b: a for a, b in self.mapped_tokens}
+            segmented = [mapped_dict.get(tok, tok) for tok in segmented]
         return segmented
 
     def _detokenize(self, tokens, side="src", is_train=False):


### PR DESCRIPTION
…config

I cherry picked and fixed everything related to `optional_eos` in #45 

Then adding here also the mapped tokens logic to support thinks like:

TowerInstruct chat template: '<im_start>' ==> '｟im_start｠'
Llama3 Instruct template: '<|start_header_id|>' ==>  '｟start_header_id｠'

An inference yaml file should look like:

```
transforms: [onmt_tokenize]

transforms_configs:
  onmt_tokenize:
    src_subword_type: bpe
    src_subword_model: "${EOLE_MODEL_DIR}/llama3.1-8b-instruct/bpe.model"
    src_onmttok_kwargs: {"mode": "space", "spacer_annotate": True, "preserve_placeholders": True}
    tgt_subword_type: bpe
    tgt_subword_model: "${EOLE_MODEL_DIR}/llama3.1-8b-instruct/bpe.model"
    tgt_onmttok_kwargs: {"mode": "space", "spacer_annotate": True, "preserve_placeholders": True}
    gpt2_pretok: true
    mapped_tokens: [['<|start_header_id|>', '｟start_header_id｠'], ['<|end_header_id|>', '｟end_header_id｠'], ['<|eot_id|>', '｟eot_id｠']]
    #mapped_tokens: [['<|im_start|>', '｟im_start｠'], ['<|im_end|>', '｟im_end｠'],]
optional_eos: ['<|eot_id|>']
#optional_eos: ['<|im_end|>']
# Model info
model_path: "${EOLE_MODEL_DIR}/llama3.1-8b-instruct"
```
