### PR TITLE
[patch] Adapt some warning behaviours for reduced verbosity

### DIFF
--- a/eole/config/training.py
+++ b/eole/config/training.py
@@ -1,5 +1,6 @@
 from typing import List, Literal
 from pydantic import Field, field_validator, model_validator, computed_field
+from functools import cached_property
 import torch
 
 from eole.config.config import Config, get_config_dict
@@ -271,7 +272,7 @@ class TrainingConfig(
     )
 
     @computed_field
-    @property
+    @cached_property
     def storage_dtype(self) -> torch.dtype:
         """
         Deduce which dtype to use for main model parameters.

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -284,9 +284,10 @@ class BaseModel(nn.Module):
         model_config = checkpoint["config"].model
         # here we need a running config updated in the same way
         training_config = checkpoint["config"].training
-        # override gpu_ranks/world_size to prevent warnings IT BREAKS WHEN ADDING THESE LINES
-        # training_config.gpu_ranks = running_config.gpu_ranks
-        # training_config.world_size = running_config.world_size
+        # override gpu_ranks/world_size to prevent warnings
+        training_config.update(
+            world_size=running_config.world_size, gpu_ranks=running_config.gpu_ranks
+        )
         # retrieve share_vocab flag from checkpoint config
         running_config.share_vocab = checkpoint["config"].share_vocab
         # retrieve precision from checkpoint config if not explicitly set


### PR DESCRIPTION
1. Fix gpu related behaviour

For reference, the error was raised here:
https://github.com/eole-nlp/eole/blob/67ccde4340812f53f83ead412bd02d8d69f615e2/eole/config/training.py#L320-L324

The issue is that `gpu_ranks` is set before updating `world_size`, so the condition cannot pass.
Updating both values with the dedicated `update` method makes it work.
Another solution would be to set `world_size` before `gpu_ranks`, but using the ad-hoc function seems better to me.

Also, this whole logic might be worth a bit of reworking, as it's not super clear from a user pov why we need to update some `training_config` in `inference_logic`...