### PR TITLE
[patch] minor fixes for 0.0.2

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -942,11 +942,12 @@ class LlamaHFConverter(BaseBin):
                 eos_token_id = config.get("eos_token_id", None)
                 if isinstance(eos_token_id, list):
                     if "added_tokens_decoder" in data.keys():
-                        optional_eos = [
+                        eos_tokens = [
                             data["added_tokens_decoder"][str(index)]["content"]
                             for index in eos_token_id[1:]
                         ]
-                    eos_token = optional_eos[0]
+                        optional_eos = eos_tokens[1:]
+                        eos_token = eos_tokens[0]
                 elif isinstance(eos_token_id, int):
                     if "eos_token" in data.keys():
                         if isinstance(data["eos_token"], dict):

--- a/eole/config/training.py
+++ b/eole/config/training.py
@@ -270,6 +270,11 @@ class TrainingConfig(
     score_threshold: float = Field(
         default=0.68, description="Threshold to filterout data"
     )
+    dummy_load: bool | None = Field(
+        default=False,
+        description="Ignore some warnings if we are only loading the configuration "
+        "prior to other operations, e.g. in `train_from` context.",
+    )
 
     @computed_field
     @cached_property
@@ -316,6 +321,7 @@ class TrainingConfig(
             torch.cuda.is_available()
             and not self.gpu_ranks
             and self.model_fields_set != set()
+            and not self.dummy_load
         ):
             logger.warn("You have a CUDA device, should run with -gpu_ranks")
         if self.world_size < len(self.gpu_ranks):

--- a/eole/models/model_saver.py
+++ b/eole/models/model_saver.py
@@ -53,6 +53,10 @@ def load_checkpoint(model_path):
                 # drop inference to prevent validation issues
                 if "inference" in config_dict.keys():
                     config_dict.pop("inference")
+                if "training" in config_dict.keys():
+                    config_dict["training"]["dummy_load"] = True
+                else:
+                    config_dict["training"] = {"dummy_load": True}
                 _config = TrainConfig(**config_dict)
                 checkpoint["config"] = _config
         else:

--- a/eole/modules/rmsnorm.py
+++ b/eole/modules/rmsnorm.py
@@ -24,7 +24,8 @@ class RMSNorm(torch.nn.Module):
         self.weight = nn.Parameter(torch.ones(hidden_size))
 
     def forward(self, hidden_states):
-        if AWQ_EXT and not self.training:
+        dtype = next(self.parameters()).dtype
+        if AWQ_EXT and not self.training and dtype == torch.float16:
             inp_type = hidden_states.dtype
             output = torch.empty_like(hidden_states).to(inp_type)
             if hidden_states.dim() == 2:  # patch for multi experts


### PR DESCRIPTION
- additions in convert_HF from #42 broke some back-compatibility (e.g. llama2), which should be restored here;
- two issues in the lora merging script should be fixed: proper conservation of inference settings + use the compute_dtype from the lora config (e.g. if we finetune with a different dtype than the original model, like fusedadam+fp16 for an originally bf16 model)