### PR TITLE
Add comet scorer

### DIFF
--- a/eole/scorers/bleu.py
+++ b/eole/scorers/bleu.py
@@ -11,7 +11,7 @@ class BleuScorer(Scorer):
         """Initialize necessary options for sentencepiece."""
         super().__init__(config)
 
-    def compute_score(self, preds, texts_refs):
+    def compute_score(self, preds, texts_refs, texts_srcs):
         if len(preds) > 0:
             score = corpus_bleu(preds, [texts_refs]).score
         else:

--- a/eole/scorers/comet-kiwi.py
+++ b/eole/scorers/comet-kiwi.py
@@ -5,10 +5,10 @@ from comet import download_model, load_from_checkpoint
 
 @register_scorer(metric="COMET-KIWI")
 class CometKiwiScorer(Scorer):
-    """COMET scorer class."""
+    """Comet-kiwi scorer class."""
 
     def __init__(self, config):
-        """Initialize necessary options for sentencepiece."""
+        """Download if needed and load Comet-kiwi model."""
         super().__init__(config)
         comet_model_name = "Unbabel/wmt22-cometkiwi-da"
         try:

--- a/eole/scorers/comet-kiwi.py
+++ b/eole/scorers/comet-kiwi.py
@@ -1,0 +1,32 @@
+from .scorer import Scorer
+from eole.scorers import register_scorer
+from comet import download_model, load_from_checkpoint
+
+
+@register_scorer(metric="COMET-KIWI")
+class CometKiwiScorer(Scorer):
+    """COMET scorer class."""
+
+    def __init__(self, config):
+        """Initialize necessary options for sentencepiece."""
+        super().__init__(config)
+        comet_model_name = "Unbabel/wmt22-cometkiwi-da"
+        try:
+            comet_model_path = download_model(comet_model_name)
+        except KeyError:
+            raise PermissionError("Use your hugginface token to download comet-kiwi:\n"
+                                  "huggingface-cli login --token hf_token")
+        self.comet_model = load_from_checkpoint(comet_model_path)
+
+    def compute_score(self, preds, texts_refs, texts_srcs):
+        data = []
+        for _src, _hyp in zip(texts_srcs, preds):
+            curr = {"src": _src, "mt": _hyp}
+            data.append(curr)
+        if len(preds) > 0:
+            score = self.comet_model.predict(
+                data, batch_size=64, gpus=0, num_workers=0, progress_bar=True)
+            score = score.system_score
+        else:
+            score = 0
+        return score

--- a/eole/scorers/comet.py
+++ b/eole/scorers/comet.py
@@ -1,0 +1,28 @@
+from .scorer import Scorer
+from eole.scorers import register_scorer
+from comet import download_model, load_from_checkpoint
+
+
+@register_scorer(metric="COMET")
+class CometScorer(Scorer):
+    """COMET scorer class."""
+
+    def __init__(self, config):
+        """Initialize necessary options for sentencepiece."""
+        super().__init__(config)
+        comet_model_name = "Unbabel/wmt22-comet-da"
+        comet_model_path = download_model(comet_model_name)
+        self.comet_model = load_from_checkpoint(comet_model_path)
+
+    def compute_score(self, preds, texts_refs, texts_srcs):
+        data = []
+        for _src, _tgt, _hyp in zip(texts_srcs, texts_refs, preds):
+            curr = {"src": _src, "mt": _hyp, "ref": _tgt}
+            data.append(curr)
+        if len(preds) > 0:
+            score = self.comet_model.predict(
+                data, batch_size=64, gpus=0, num_workers=0, progress_bar=True)
+            score = score.system_score
+        else:
+            score = 0
+        return score

--- a/eole/scorers/comet.py
+++ b/eole/scorers/comet.py
@@ -5,10 +5,10 @@ from comet import download_model, load_from_checkpoint
 
 @register_scorer(metric="COMET")
 class CometScorer(Scorer):
-    """COMET scorer class."""
+    """Comet scorer class."""
 
     def __init__(self, config):
-        """Initialize necessary options for sentencepiece."""
+        """Download if needed and load Comet model."""
         super().__init__(config)
         comet_model_name = "Unbabel/wmt22-comet-da"
         comet_model_path = download_model(comet_model_name)

--- a/eole/scorers/cometinho.py
+++ b/eole/scorers/cometinho.py
@@ -1,0 +1,28 @@
+from .scorer import Scorer
+from eole.scorers import register_scorer
+from comet import download_model, load_from_checkpoint
+
+
+@register_scorer(metric="COMETINHO")
+class CometinhoScorer(Scorer):
+    """COMET scorer class."""
+
+    def __init__(self, config):
+        """Initialize necessary options for sentencepiece."""
+        super().__init__(config)
+        comet_model_name = "Unbabel/eamt22-cometinho-da"
+        comet_model_path = download_model(comet_model_name)
+        self.comet_model = load_from_checkpoint(comet_model_path)
+
+    def compute_score(self, preds, texts_refs, texts_srcs):
+        data = []
+        for _src, _tgt, _hyp in zip(texts_srcs, texts_refs, preds):
+            curr = {"src": _src, "mt": _hyp, "ref": _tgt}
+            data.append(curr)
+        if len(preds) > 0:
+            score = self.comet_model.predict(
+                data, batch_size=64, gpus=0, num_workers=0, progress_bar=True)
+            score = score.system_score
+        else:
+            score = 0
+        return score

--- a/eole/scorers/cometinho.py
+++ b/eole/scorers/cometinho.py
@@ -5,10 +5,10 @@ from comet import download_model, load_from_checkpoint
 
 @register_scorer(metric="COMETINHO")
 class CometinhoScorer(Scorer):
-    """COMET scorer class."""
+    """Cometinho scorer class."""
 
     def __init__(self, config):
-        """Initialize necessary options for sentencepiece."""
+        """Download if needed and load Cometinho model."""
         super().__init__(config)
         comet_model_name = "Unbabel/eamt22-cometinho-da"
         comet_model_path = download_model(comet_model_name)

--- a/eole/scorers/scorer.py
+++ b/eole/scorers/scorer.py
@@ -8,7 +8,7 @@ class Scorer(object):
         # not used by any scorer for now it seems, but why not
         self.config = config
 
-    def compute_score(self, preds, texts_refs):
+    def compute_score(self, preds, texts_refs, texts_srcs):
         raise NotImplementedError
 
 

--- a/eole/scorers/ter.py
+++ b/eole/scorers/ter.py
@@ -11,7 +11,7 @@ class TerScorer(Scorer):
         """Initialize necessary options for sentencepiece."""
         super().__init__(config)
 
-    def compute_score(self, preds, texts_refs):
+    def compute_score(self, preds, texts_refs, texts_srcs):
         if len(preds) > 0:
             score = corpus_ter(preds, [texts_refs]).score
         else:

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -216,7 +216,7 @@ class Trainer(object):
         # Set model in training mode.
         self.model.train()
 
-    def _eval_handler(self, scorer, preds, texts_ref):
+    def _eval_handler(self, scorer, preds, texts_ref, texts_src):
         """Trigger metrics calculations
 
         Args:
@@ -226,7 +226,7 @@ class Trainer(object):
         Returns:
             The metric calculated by the scorer."""
 
-        return scorer.compute_score(preds, texts_ref)
+        return scorer.compute_score(preds, texts_ref, texts_src)
 
     def _accum_count(self, step):
         for i in range(len(self.accum_steps)):
@@ -437,7 +437,7 @@ class Trainer(object):
             if len(self.valid_scorers) > 0:
                 computed_metrics = {}
                 start = time.time()
-                preds, texts_ref = self.scoring_preparator.translate(
+                preds, texts_ref, texts_src = self.scoring_preparator.translate(
                     model=self.model,
                     gpu_rank=self.gpu_rank,
                     step=self.optim.training_step,
@@ -454,6 +454,7 @@ class Trainer(object):
                         scorer=self.valid_scorers[metric]["scorer"],
                         preds=preds,
                         texts_ref=texts_ref,
+                        texts_src=texts_src
                     )
                     computed_metrics[metric] = self.valid_scorers[metric]["value"]
                     logger.info(

--- a/eole/utils/scoring_utils.py
+++ b/eole/utils/scoring_utils.py
@@ -132,4 +132,4 @@ class ScoringPreparator:
                     file.write("SOURCE: {}\n".format(raw_srcs[i]))
                     file.write("REF: {}\n".format(raw_refs[i]))
                     file.write("PRED: {}\n\n".format(preds[i]))
-        return preds, raw_refs
+        return preds, raw_refs, raw_srcs

--- a/recipes/wmt17/README.md
+++ b/recipes/wmt17/README.md
@@ -10,7 +10,8 @@ To make your life easier, run these commands from the recipe directory (here `re
 WMT17 English-German data set:
 
 ```bash
-cd recipes/wmt17
+cd /eole/recipes/wmt17
+apt-get install wget
 bash prepare_wmt_ende_data.sh
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "subword-nmt>=0.3.7",
         "tensorboard>=2.3",
         "torch>=2.3,<2.4",
+        "unbabel-comet==2.2.2"
         "uvicorn",
         "waitress",
     ],


### PR DESCRIPTION
Added comet scorers for validation in NMT training.
I left `progress_bar=True`, `num_workers=0`, `batch_size=64` and `gpu=0` for cpu inference, should it be like that by default and should it be modifiable via config ?
I did not modify tests as it would greatly extend the tests duration (downloading comet models and inferencing on cpu).
I also took the liberty to lightly modify wmt17 recipe/doc to make it more beginner friendly.