### PR TITLE
Fix coverage penalty (wu)

### DIFF
--- a/eole/predict/beam_search.py
+++ b/eole/predict/beam_search.py
@@ -359,13 +359,14 @@ class BeamSearchBase(DecodeStrategy):
             current_attn = attn[self.select_indices]
             if step == 1:
                 # update global state (step == 1)
-                self.alive_attn = current_attn
+                if self.return_attention:
+                    self.alive_attn = current_attn
                 if self._cov_pen:  # coverage penalty
                     self._prev_penalty = torch.zeros_like(self.topk_log_probs)
                     self._coverage = torch.zeros(
                         [self.beam_size * _B, 1, attn.size(-1)], device=attn.device
                     )
-            else:
+            elif self.return_attention:
                 self.alive_attn = self.alive_attn[self.select_indices]
                 self.alive_attn = torch.cat([self.alive_attn, current_attn], 1)
 

--- a/eole/predict/beam_search.py
+++ b/eole/predict/beam_search.py
@@ -356,13 +356,18 @@ class BeamSearchBase(DecodeStrategy):
         self.maybe_update_forbidden_tokens()
 
         if self.return_attention or self._cov_pen:
+            current_attn = attn[self.select_indices]
             if step == 1:
                 # update global state (step == 1)
+                self.alive_attn = current_attn
                 if self._cov_pen:  # coverage penalty
                     self._prev_penalty = torch.zeros_like(self.topk_log_probs)
                     self._coverage = torch.zeros(
                         [self.beam_size * _B, 1, attn.size(-1)], device=attn.device
                     )
+            else:
+                self.alive_attn = self.alive_attn[self.select_indices]
+                self.alive_attn = torch.cat([self.alive_attn, current_attn], 1)
 
         if self._vanilla_cov_pen and step > 1:
             # shape: (batch_size x beam_size, 1)

--- a/eole/predict/beam_search.py
+++ b/eole/predict/beam_search.py
@@ -356,11 +356,10 @@ class BeamSearchBase(DecodeStrategy):
         self.maybe_update_forbidden_tokens()
 
         if self.return_attention or self._cov_pen:
-            current_attn = attn[self.select_indices]
             if step == 1:
                 # update global state (step == 1)
                 if self.return_attention:
-                    self.alive_attn = current_attn
+                    self.alive_attn = attn[self.select_indices]
                 if self._cov_pen:  # coverage penalty
                     self._prev_penalty = torch.zeros_like(self.topk_log_probs)
                     self._coverage = torch.zeros(
@@ -368,12 +367,18 @@ class BeamSearchBase(DecodeStrategy):
                     )
             elif self.return_attention:
                 self.alive_attn = self.alive_attn[self.select_indices]
-                self.alive_attn = torch.cat([self.alive_attn, current_attn], 1)
+                self.alive_attn = torch.cat(
+                    [self.alive_attn, attn[self.select_indices]], 1
+                )
 
         if self._vanilla_cov_pen and step > 1:
             # shape: (batch_size x beam_size, 1)
             self._coverage = torch.cat(
-                [self._coverage, attn[:, :, : self._coverage.size(-1)]], dim=1
+                [
+                    self._coverage[self.select_indices],
+                    attn[:, :, : self._coverage.size(-1)],
+                ],
+                dim=1,
             )
             cov_penalty = self.global_scorer.cov_penalty(
                 self._coverage, beta=self.global_scorer.beta

--- a/eole/predict/penalties.py
+++ b/eole/predict/penalties.py
@@ -65,7 +65,7 @@ class PenaltyBuilder(object):
         then the ``seq_len`` axis probably sums to (almost) 1.
         """
 
-        penalty = -torch.min(cov, cov.clone().fill_(1.0)).log().sum(-1)
+        penalty = torch.min(cov.sum(1), cov.clone().sum(1).fill_(1.0)).log().sum(1)
         return beta * penalty
 
     def coverage_summary(self, cov, beta=0.0):


### PR DESCRIPTION
When I use 
```yaml
beam_size: 2
coverage_penalty: 'wu'
beta: 1
```

In my decoding config, I have the following error

```shell
Traceback (most recent call last):
  File "/usr/local/bin/eole", line 33, in <module>
    sys.exit(load_entry_point('EOLE', 'console_scripts', 'eole')())
  File "/workdir/eole/eole/bin/main.py", line 39, in main
    bin_cls.run(args)
  File "/workdir/eole/eole/bin/run/predict.py", line 42, in run
    predict(config)
  File "/workdir/eole/eole/bin/run/predict.py", line 18, in predict
    _, _, _ = engine.infer_file()
  File "/workdir/eole/eole/inference_engine.py", line 38, in infer_file
    scores, estims, preds = self._predict(infer_iter)
  File "/workdir/eole/eole/inference_engine.py", line 170, in _predict
    scores, estims, preds = self.predictor._predict(
  File "/workdir/eole/eole/predict/inference.py", line 475, in _predict
    batch_data = self.predict_batch(batch, attn_debug)
  File "/workdir/eole/eole/predict/generator.py", line 71, in predict_batch
    return self._predict_batch_with_strategy(batch, decode_strategy)
  File "/workdir/eole/eole/predict/generator.py", line 149, in _predict_batch_with_strategy
    decode_strategy.advance(log_probs, attn)
  File "/workdir/eole/eole/predict/beam_search.py", line 437, in advance
    super(BeamSearchLM, self).advance(log_probs, attn)
  File "/workdir/eole/eole/predict/beam_search.py", line 383, in advance
    self.topk_scores -= cov_penalty.view(_B, self.beam_size).float()
RuntimeError: shape '[1, 2]' is invalid for input of size 518
```
I have tried to fix it but it revamps a bit the penalty calculation.
 I calculate it "from scratch" at each decoding step, using the attentions.