### PR TITLE
Some QOL config/saving improvements

### DIFF
--- a/eole/config/inference.py
+++ b/eole/config/inference.py
@@ -105,23 +105,6 @@ class InferenceConfig(RunningConfig, DecodingConfig, LoRaConfig, QuantizeConfig)
     model_config = get_config_dict()
     model_config["arbitrary_types_allowed"] = True  # to allow torch.dtype
 
-    # TODO: clarify models vs model (model config retrieved from checkpoint)
-    model_path: str | List[str] = Field(
-        description="Path to model .pt file(s). "
-        "Multiple models can be specified for ensemble decoding."
-    )  # some specific (mapping to "models") in legacy code, need to investigate
-    src: str = Field(description="Source file to decode (one line per sequence).")
-    tgt: str | None = Field(
-        default=None,
-        description="True target sequences, useful for scoring or prefix decoding.",
-    )
-    tgt_file_prefix: bool = Field(
-        default=False, description="Generate predictions using provided tgt as prefix."
-    )
-    output: str = Field(
-        default="pred.txt",
-        description="Path to output the predictions (each line will be the decoded sequence).",
-    )
     report_align: bool = Field(
         default=False, description="Report alignment for each translation."
     )
@@ -147,6 +130,11 @@ class InferenceConfig(RunningConfig, DecodingConfig, LoRaConfig, QuantizeConfig)
     )
     data_type: str | None = (
         "text"  # deprecated? hopefully will change with input streams logic
+    )
+    chat_template: str | None = None
+    optional_eos: List[str] | None = Field(
+        default=[],
+        description="Optional EOS tokens that would stop generation, e.g. <|eot_id|> for Llama3",
     )
 
     def get_model_path(self):

--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -34,6 +34,7 @@ class TrainConfig(
     )  # not sure this still works
     model: ModelConfig | None = None  # TypeAdapter handling discrimination directly
     training: TrainingConfig | None = Field(default_factory=TrainingConfig)
+    inference: InferenceConfig | None = Field(default=None)
 
     def get_model_path(self):
         return self.training.get_model_path()
@@ -100,10 +101,21 @@ class PredictConfig(
         None  # patch for CT2 inference engine (to improve later)
     )
     model: ModelConfig | None = None
-    chat_template: str | None = None
-    optional_eos: List[str] | None = Field(
-        default=[],
-        description="Optional EOS tokens that would stop generation, e.g. <|eot_id|> for Llama3",
+    model_path: str | List[str] = Field(
+        description="Path to model .pt file(s). "
+        "Multiple models can be specified for ensemble decoding."
+    )  # some specific (mapping to "models") in legacy code, need to investigate
+    src: str = Field(description="Source file to decode (one line per sequence).")
+    tgt: str | None = Field(
+        default=None,
+        description="True target sequences, useful for scoring or prefix decoding.",
+    )
+    tgt_file_prefix: bool = Field(
+        default=False, description="Generate predictions using provided tgt as prefix."
+    )
+    output: str = Field(
+        default="pred.txt",
+        description="Path to output the predictions (each line will be the decoded sequence).",
     )
 
     @model_validator(mode="after")

--- a/eole/transforms/transform.py
+++ b/eole/transforms/transform.py
@@ -58,6 +58,7 @@ class Transform(object):
 
     def _save_artifacts(self, model_path):
         save_config = copy.deepcopy(self.config)
+        artifacts = []
         for artifact in self.artifacts:
             maybe_artifact = getattr(self, artifact, None)
             if maybe_artifact is not None and os.path.exists(maybe_artifact):
@@ -66,12 +67,14 @@ class Transform(object):
                     shutil.copy(maybe_artifact, model_path)
                 except shutil.SameFileError:
                     pass
-                setattr(
-                    save_config,
-                    artifact,
-                    os.path.join("${MODEL_PATH}", os.path.basename(maybe_artifact)),
-                )
-        return save_config
+                finally:
+                    artifacts.append(os.path.basename(maybe_artifact))
+                    setattr(
+                        save_config,
+                        artifact,
+                        os.path.join("${MODEL_PATH}", os.path.basename(maybe_artifact)),
+                    )
+        return save_config, artifacts
 
     @classmethod
     def add_options(cls, parser):


### PR DESCRIPTION
1. Previously, the transforms artifacts were saved only in the "root" model_path, so not accessible by default within the step_# checkpoints. This PR applies the same logic as all the other items to the transform artifacts : save the file in the step_dir, and create a symlink to the latest in the root dir.
2. To prevent validation issues, when finetuning a model with the "inference" key in its `config.json`, this key was popped prior to instantiating the `TrainConfig`. That prevents the downstream transparent use of these inference settings. This PR adds an explicit `inference` field to `TrainConfig`, which allows to properly retain it all along. It will also allow to modify the validation/inference codepath to use the "proper" settings rather than relying on defaults.