### PR TITLE
fix #136. Updated eole/bin/model/average_models.py to work with safetensors model format.

### DIFF
--- a/eole/bin/model/average_models.py
+++ b/eole/bin/model/average_models.py
@@ -16,18 +16,18 @@ def average_models(model_paths, fp32=False):
     for i, model_path in enumerate(model_paths):
         m = model_saver.load_checkpoint(model_path)
         model_weights = load_file(os.path.join(model_path, "model.00.safetensors"))
-        
+
         if fp32:
             for k, v in model_weights.items():
                 model_weights[k] = v.float()
-        
+
         if i == 0:
             vocab, config, optim = m["vocab"], m["config"], m["optim"]
             avg_model = model_weights
         else:
             for k, v in avg_model.items():
                 avg_model[k].mul_(i).add_(model_weights[k]).div_(i + 1)
-        
+
     final = {
         "vocab": vocab,
         "config": config,

--- a/eole/bin/model/average_models.py
+++ b/eole/bin/model/average_models.py
@@ -6,14 +6,12 @@ from eole.config import recursive_model_fields_set
 from safetensors.torch import load_file, save_file
 import os
 import json
-import pdb
 
 
 def average_models(model_paths, fp32=False):
     vocab = None
     config = None
     avg_model = None
-    avg_generator = None
 
     for i, model_path in enumerate(model_paths):
         # torch pt code

--- a/eole/bin/model/average_models.py
+++ b/eole/bin/model/average_models.py
@@ -56,6 +56,8 @@ class AverageModels(BaseBin):
         if not os.path.isdir(args.output):
             os.makedirs(args.output, exist_ok=True)
 
+        # this maybe better implemented using model_saver classes
+        # config
         with open(os.path.join(args.output, "config.json"), "w") as f:
             json.dump(
                 recursive_model_fields_set(final["config"]),
@@ -63,9 +65,10 @@ class AverageModels(BaseBin):
                 indent=2,
                 ensure_ascii=False,
             )
-
+        # vocab
         with open(os.path.join(args.output, "vocab.json"), "w") as f:
             json.dump(final["vocab"], f, indent=2, ensure_ascii=False)
-
+        # optimizer
         torch.save(final["optim"], os.path.join(args.output, "optimizer.pt"))
+        # model weights
         save_file(final["model"], os.path.join(args.output, "model.00.safetensors"))

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -335,7 +335,7 @@ class Trainer(object):
 
             if self.n_gpu > 1 and self.parallel_mode == "data_parallel":
                 normalization = sum(
-                    eole.utils.distributed.all_gather_list(normalization)
+                    all_gather_list(normalization)
                 )
 
             self._gradient_accumulation(
@@ -571,7 +571,7 @@ class Trainer(object):
                 for p in self.model.parameters()
                 if p.requires_grad and p.grad is not None
             ]
-            eole.utils.distributed.all_reduce_and_rescale_tensors(
+            all_reduce_and_rescale_tensors(
                 grads, float(self.n_gpu)
             )
 

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -14,7 +14,7 @@ import sys
 import torch
 import traceback
 import eole.utils
-from eole.utils import distributed
+from eole.utils.distributed import all_gather_list,all_reduce_and_rescale_tensors
 from eole.utils.loss import LossCompute
 from eole.utils.logging import logger
 from eole.utils.misc import clear_gpu_cache, get_autocast

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -14,7 +14,7 @@ import sys
 import torch
 import traceback
 import eole.utils
-from eole.utils.distributed import all_gather_list,all_reduce_and_rescale_tensors
+from eole.utils.distributed import all_gather_list, all_reduce_and_rescale_tensors
 from eole.utils.loss import LossCompute
 from eole.utils.logging import logger
 from eole.utils.misc import clear_gpu_cache, get_autocast

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -334,9 +334,7 @@ class Trainer(object):
             self._maybe_update_estim_lambda(step)
 
             if self.n_gpu > 1 and self.parallel_mode == "data_parallel":
-                normalization = sum(
-                    all_gather_list(normalization)
-                )
+                normalization = sum(all_gather_list(normalization))
 
             self._gradient_accumulation(
                 batches, normalization, total_stats, report_stats
@@ -571,9 +569,7 @@ class Trainer(object):
                 for p in self.model.parameters()
                 if p.requires_grad and p.grad is not None
             ]
-            all_reduce_and_rescale_tensors(
-                grads, float(self.n_gpu)
-            )
+            all_reduce_and_rescale_tensors(grads, float(self.n_gpu))
 
         self.optim.step()
 

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -14,6 +14,7 @@ import sys
 import torch
 import traceback
 import eole.utils
+from eole.utils import distributed
 from eole.utils.loss import LossCompute
 from eole.utils.logging import logger
 from eole.utils.misc import clear_gpu_cache, get_autocast


### PR DESCRIPTION
 fix proposal for #136. 
Updated eole/bin/model/average_models.py to work with safetensors model format. 
The script now takes as input/ouput checkpoint directory paths instead of `.pt` model files.
I've used `model_saver` package functions (`eole/models/model_saver.py`) to load checkpoints.

I tested it with a few models and results seem as expected, but feel free to check if code is correct.

