### PR TITLE
fix lora lm head

### DIFF
--- a/eole/bin/model/lora_weights.py
+++ b/eole/bin/model/lora_weights.py
@@ -84,7 +84,6 @@ class LoraWeights(BaseBin):
 
         if args.action == "merge":
             model.eval()  # this merges automatically LoRa weights in main
-            model.half()  # We keep FP16 for all
             optim = None
             model_state_dict = model.state_dict()
             new_config = base_checkpoint["config"]

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -490,6 +490,7 @@ class Trainer(object):
         if self.accum_count > 1:
             self.optim.zero_grad(set_to_none=True)
 
+        skip_batch = False
         for k, batch in enumerate(true_batches):
             target_size = batch["tgt"].size(1)
             # Truncated BPTT: reminder not compatible with accum > 1
@@ -534,6 +535,10 @@ class Trainer(object):
                             trunc_size=trunc_size,
                             estim=estim,
                         )
+                    if torch.isnan(loss):
+                        print("NaN detected in loss, skipping this batch.")
+                        skip_batch = True
+                        break
                     if loss is not None:
                         loss /= normalization
                         auxloss /= self.accum_count * src_len.size(0)
@@ -562,6 +567,8 @@ class Trainer(object):
                 if self.model.decoder is not None and self.model.decoder.state != {}:
                     self.model.decoder.detach_state()
 
+            if skip_batch:
+                break
         # in case of multi step gradient accumulation,
         # update only after accum batches
         if self.n_gpu > 1 and self.parallel_mode == "data_parallel":


### PR DESCRIPTION
When choosing to use lora embedding, if the lm head is not shared with decoder embedding it was not trained.

I could make a separate setting between lora embedding and lm head but chose to make it common.