### PR TITLE
Gemma2 support

### DIFF
--- a/eole/constants.py
+++ b/eole/constants.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import torch
-from eole.modules.rmsnorm import RMSNorm
+from eole.modules.rmsnorm import RMSNorm, GemmaRMSNorm
 import torch.nn.functional as F
 
 
@@ -79,7 +79,11 @@ ACTIVATION_FUNCTIONS = {
 }
 
 
-LayerNorm = {"standard": torch.nn.LayerNorm, "rms": RMSNorm}
+LayerNorm = {
+    "standard": torch.nn.LayerNorm,
+    "rms": RMSNorm,
+    "gemma-rms": GemmaRMSNorm,
+}
 
 
 TORCH_DTYPES = {

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -82,6 +82,7 @@ def build_src_emb(model_config, vocabs, running_config=None):
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_enc,
         n_positions=model_config.embeddings.n_positions,
+        normalize=model_config.embeddings.normalize,
     )
     return src_emb
 
@@ -99,6 +100,7 @@ def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=Fa
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_dec,
         n_positions=model_config.embeddings.n_positions,
+        normalize=model_config.embeddings.normalize,
     )
 
     if share_embeddings:

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -93,6 +93,7 @@ class Embeddings(nn.Module):
         sparse=False,
         freeze_word_vecs=False,
         n_positions=1024,
+        normalize=False,
     ):
         super(Embeddings, self).__init__()
         self._validate_args()
@@ -114,6 +115,7 @@ class Embeddings(nn.Module):
 
         self.position_encoding_type = position_encoding_type
         self.position_shift = position_shift
+        self.normalize = normalize
 
         if self.position_encoding_type == PositionEncodingType.Learned:
             self.pe = nn.Embedding(n_positions, word_vec_size)
@@ -184,6 +186,10 @@ class Embeddings(nn.Module):
             PositionEncodingType.SinusoidalConcat,
         ]:
             emb = self.pe(emb, step)
+
+        if self.normalize:
+            normalizer = torch.tensor(self.word_vec_size**0.5, dtype=emb.dtype)
+            emb = emb * normalizer
 
         if self.dropout_p > 0:
             return self.dropout(emb)

--- a/recipes/model-validator/run.sh
+++ b/recipes/model-validator/run.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Define the models table
 models=(
     # Validated
+    "google/gemma-2-2b"
     "mistralai/Ministral-8B-Instruct-2410"
     "mistralai/Mistral-7B-v0.3"
     "mistralai/Mistral-7B-Instruct-v0.3"


### PR DESCRIPTION
As always, some slight differences remain with the HF implementation.
Notably it does not implement the ["approximate" gelu](https://github.com/huggingface/transformers/pull/29402) for now.
Also, the `ffn_layernom` path is currently incompatible with context attention (encoder/decoder).