### PR TITLE
[patch] remove dummy_load, move gpu_ranks warning out of TrainingConfig

### DIFF
--- a/eole/config/training.py
+++ b/eole/config/training.py
@@ -273,11 +273,6 @@ class TrainingConfig(
     score_threshold: float = Field(
         default=0.68, description="Threshold to filterout data"
     )
-    dummy_load: bool | None = Field(
-        default=False,
-        description="Ignore some warnings if we are only loading the configuration "
-        "prior to other operations, e.g. in `train_from` context.",
-    )
 
     @computed_field
     @cached_property
@@ -323,13 +318,6 @@ class TrainingConfig(
     def _validate_running_config(self):
         super()._validate_running_config()
         # self._validate_language_model_compatibilities_opts()
-        if (
-            torch.cuda.is_available()
-            and not self.gpu_ranks
-            and self.model_fields_set != set()
-            and not self.dummy_load
-        ):
-            logger.warn("You have a CUDA device, should run with -gpu_ranks")
         if self.world_size < len(self.gpu_ranks):
             raise AssertionError(
                 "parameter counts of -gpu_ranks must be less or equal "

--- a/eole/models/model_saver.py
+++ b/eole/models/model_saver.py
@@ -52,10 +52,6 @@ def load_checkpoint(model_path):
                 config_dict = json.loads(os.path.expandvars(f.read()))
                 # drop data to prevent validation issues
                 config_dict["data"] = {}
-                if "training" in config_dict.keys():
-                    config_dict["training"]["dummy_load"] = True
-                else:
-                    config_dict["training"] = {"dummy_load": True}
                 _config = TrainConfig(**config_dict)
                 checkpoint["config"] = _config
         else:


### PR DESCRIPTION
#163 introduced an issue when loading a finetuned model with a remanent `dummy_load` attribute.

This `dummy_load` attribute is a bit messy and its only purpose was to limit the `gpu_ranks` related warnings. Moving these warnings out of `TrainingConfig` allows to remove this attribute.