### PR TITLE
[patch] handle self_attn_backend edge case

### DIFF
--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -1,6 +1,6 @@
 import torch
 from typing import List, Literal, Union
-from pydantic import Field, model_validator, field_validator
+from pydantic import Field, field_validator
 from importlib import import_module
 from eole.config.config import Config, get_config_dict
 from eole.constants import TORCH_DTYPES
@@ -129,8 +129,7 @@ class RunningConfig(DistributedConfig):
                 raise ValueError(f"Invalid compute_dtype value: {v}")
         return v
 
-    @model_validator(mode="after")
-    def _validate_running_config(self):
+    def check_self_attn_backend(self):
         try:
             flash_pack = import_module("flash_attn")
             if (
@@ -144,4 +143,3 @@ class RunningConfig(DistributedConfig):
                 self.__dict__["self_attn_backend"] = "pytorch"
         except ImportError:
             self.__dict__["self_attn_backend"] = "pytorch"
-        return self

--- a/eole/config/inference.py
+++ b/eole/config/inference.py
@@ -123,7 +123,7 @@ class InferenceConfig(RunningConfig, DecodingConfig, LoRaConfig, QuantizeConfig)
 
     @model_validator(mode="after")
     def _validate_running_config(self):
-        super()._validate_running_config()
+        # super()._validate_running_config()
         if self.gold_align:
             assert self.report_align, "-report_align should be enabled with -gold_align"
             assert not self.replace_unk, "-replace_unk option can not be used with -gold_align enabled"

--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -120,6 +120,7 @@ class PredictConfig(
     def _validate_predict_config(self):
         # Not sure we want to call this at every validation
         self._update_with_model_config()
+        self.check_self_attn_backend()
         # TODO: do we really need this _all_transform?
         if self._all_transform is None:
             self._all_transform = self.transforms

--- a/eole/config/training.py
+++ b/eole/config/training.py
@@ -269,7 +269,7 @@ class TrainingConfig(
 
     @model_validator(mode="after")
     def _validate_running_config(self):
-        super()._validate_running_config()
+        self.check_self_attn_backend()
         # self._validate_language_model_compatibilities_opts()
         if self.world_size < len(self.gpu_ranks):
             raise AssertionError("parameter counts of -gpu_ranks must be less or equal " "than -world_size.")


### PR DESCRIPTION
When relying on the model's config.json `compute_dtype` at inference, the following case could happen:
- no `compute_dtype` explicitly set in the original config/cli
- => defaults to `float32`
- => `config.self_attn_backend` falls back to `pytorch`
And later down the line, when the `compute_dtype` has been updated from loading the model's config, `config.self_attn_backend` is still `pytorch`, so it can't be set back to `flash`.

This PR makes this check explicitly happen after the `update_with_model_config` call, so that everything is up to date when checking for flash compatibility.