### PR TITLE
[patch] Add missing `is_train` kwarg in `tokenize_id`

### DIFF
--- a/eole/transforms/tokenize_id.py
+++ b/eole/transforms/tokenize_id.py
@@ -96,10 +96,10 @@ class HuggingfaceTokenizer(IntTokenizerTransform):
         return tokens
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
-        src_tokens = self.tokenize_string(" ".join(example["src"]), side="src")
+        src_tokens = self.tokenize_string(" ".join(example["src"]), side="src", is_train=is_train)
         example["src_ids"] = src_tokens
         if example.get("tgt", None) is not None:
-            tgt_tokens = self.tokenize_string(" ".join(example["tgt"]), side="tgt")
+            tgt_tokens = self.tokenize_string(" ".join(example["tgt"]), side="tgt", is_train=is_train)
             example["tgt_ids"] = tgt_tokens
         return example
 


### PR DESCRIPTION
The `is_train` flag was not passed fully, so `max_length` was never applied, leading to OOM issues for long un-truncated data.