### PR TITLE
patch max_length handling in tokenize_id

### DIFF
--- a/eole/transforms/tokenize_id.py
+++ b/eole/transforms/tokenize_id.py
@@ -89,7 +89,11 @@ class HuggingfaceTokenizer(IntTokenizerTransform):
 
     def tokenize_string(self, string, side="src", is_train=False):
         if self.max_length is not None and is_train:
-            kwargs = {"max_length": self.max_length, "truncation": True}
+            max_length = self.max_length
+            decoder_start_token = self.full_config.decoder_start_token
+            if side == "tgt" and self.full_config.model.encoder is None and decoder_start_token == "":
+                max_length += 1
+            kwargs = {"max_length": max_length, "truncation": True}
         else:
             kwargs = {}
         tokens = self.tokenizers[side].encode(string, **kwargs)


### PR DESCRIPTION
Fix #191 

The issue was linked to `add_bos_token` (HF) // `decoder_start_token` (eole) behaviour. When such option is set, an `eos` token will be prepended to the src side, which balances the `bos` token added to the tgt side.
When not set, we need to offset max_length by 1 for the tgt side to be long enough for downstream offset by 1.

-----
## E.g. with max_length 64

**llama2-7b-chat-hf**
`"decoder_start_token": "<s>"`

```
64 // <s> Below is an instruction that describes a task. Write a response that appropriately completes the request.｟newline｠｟newline｠### Instruction:｟newline｠Give three tips for staying healthy.｟new
64 // Below is an instruction that describes a task. Write a response that appropriately completes the request.｟newline｠｟newline｠### Instruction:｟newline｠Give three tips for staying healthy.｟new</s>
```

**EuroLLM-9B-Instruct**
`"decoder_start_token": ""`
```
(detokenized src_ids) // 64 // Below is an instruction that describes a task. Write a response that appropriately completes the request.｟newline｠｟newline｠### Instruction:｟newline｠Give three tips for staying healthy.｟newline｠｟
(detokenized tgt_ids) // 65 // Below is an instruction that describes a task. Write a response that appropriately completes the request.｟newline｠｟newline｠### Instruction:｟newline｠Give three tips for staying healthy.｟newline｠｟<|im_end|>
```

=> TGT will be offset by 1 here

https://github.com/eole-nlp/eole/blob/40ed6ea8c967107ac7da33aa926433845ee2d268/eole/inputters/text_utils.py#L92-L93
-----

This is a bit messy, but I'm not sure how we can simplify this while supporting the various cases.