### PR TITLE
Fix docs build/deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: 20
     - name: Install Eole
-      run: pip install -e .
+      run: pip install .
     - name: Install pandoc (bibtex to markdown)
       run: |
         wget https://github.com/jgm/pandoc/releases/download/3.2.1/pandoc-3.2.1-1-amd64.deb;


### PR DESCRIPTION
For a few versions, the docs build/deploy action had been failing for an unclear reason (permission denied).
It seems that disabling the "-e" flag of pip fixes the permission error. Some default permissions were probably modified on the backend, preventing from installing "in place". I don't think it was necessary here anyways.