### PR TITLE
[WIP] Gemma3

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -151,6 +151,38 @@ MODEL_OVERRIDES = {
         "adapter.w_out.weight": "multi_modal_projector.linear_2.weight",
         "adapter.w_out.bias": "multi_modal_projector.linear_2.bias",
     },
+    "Gemma3ForConditionalGeneration": {
+        "decoder_layer_prefix": "language_model.model.layers.",
+        "tgt_emb.embeddings.weight": "language_model.model.embed_tokens.weight",
+        "decoder.layer_norm.weight": "language_model.model.norm.weight",
+        # "generator.weight": "language_model.lm_head.weight", # probably shared with embeddings
+        "encoder.patch_conv.weight": "vision_tower.vision_model.embeddings.patch_embedding.weight",
+        "encoder.patch_conv.bias": "vision_tower.vision_model.embeddings.patch_embedding.bias",
+        "encoder.post_layernorm.weight": "vision_tower.vision_model.post_layernorm.weight",
+        "encoder.post_layernorm.bias": "vision_tower.vision_model.post_layernorm.bias",
+        "encoder.position_embeddings.weight": "vision_tower.vision_model.embeddings.position_embedding.weight",
+        # "encoder.ln_pre.weight": "vision_tower.ln_pre.weight", # no ln_pre in Gemma3
+        "encoder_layer_prefix": "vision_tower.vision_model.encoder.layers.",
+        ".self_attn.q_norm.": ".self_attn.q_norm.",
+        ".self_attn.k_norm.": ".self_attn.k_norm.",
+        ".pre_feedforward_layernorm.weight": ".pre_feedforward_layernorm.weight",
+        ".post_feedforward_layernorm.weight": ".post_feedforward_layernorm.weight",
+        "encoder": {
+            ".self_attn.linear_query.": ".self_attn.q_proj.",
+            ".self_attn.linear_keys.": ".self_attn.k_proj.",
+            ".self_attn.linear_values.": ".self_attn.v_proj.",
+            ".self_attn.final_linear.": ".self_attn.out_proj.",
+            ".mlp.gate_up_proj.": ".mlp.fc1.",
+            ".mlp.down_proj.": ".mlp.fc2.",
+            ".input_layernorm.weight": ".layer_norm1.weight",
+            ".input_layernorm.bias": ".layer_norm1.bias",
+            ".post_attention_layernorm.weight": ".layer_norm2.weight",
+            ".post_attention_layernorm.bias": ".layer_norm2.bias",
+        },
+        # TODO: not the same adapter as llava
+        "adapter.w_in.weight": ("multi_modal_projector.mm_input_projection_weight", ".t()"),
+        "adapter.norm.weight": "multi_modal_projector.mm_soft_emb_norm.weight",
+    },
     "M2M100ForConditionalGeneration": {
         "encoder_layer_prefix": "model.encoder.layers.",
         "decoder_layer_prefix": "model.decoder.layers.",
@@ -203,6 +235,7 @@ LN_TABLE = defaultdict(
         "XLMRobertaXLForMaskedLM": "standard",
         "Gemma2ForCausalLM": "gemma-rms",
         "M2M100ForConditionalGeneration": "standard",
+        "Gemma3ForConditionalGeneration": "gemma-rms",
     },
 )
 
@@ -214,6 +247,7 @@ ACT_TABLE = defaultdict(
         "GPT2LMHeadModel": "gelu",
         "XLMRobertaXLForMaskedLM": "gelu",
         "Gemma2ForCausalLM": "gated-gelu",
+        "Gemma3ForConditionalGeneration": "gated-gelu-tanh",
         "M2M100ForConditionalGeneration": "relu",
     },
 )
@@ -224,6 +258,7 @@ ARCH_TABLE = defaultdict(
     {
         "XLMRobertaXLForMaskedLM": TransformerEncoderModelConfig,
         "LlavaForConditionalGeneration": VisionTransformerLMModelConfig,
+        "Gemma3ForConditionalGeneration": VisionTransformerLMModelConfig,
         "M2M100ForConditionalGeneration": TransformerModelConfig,
     },
 )
@@ -360,7 +395,14 @@ class HuggingfaceFiles:
     @property
     def vocab_size(self):
         config = self.config.get("text_config", self.config)
-        return config["vocab_size"]
+        if "vocab_size" in config:
+            return config["vocab_size"]
+        tokenizer = self.tokenizer
+        if tokenizer:
+            max_added_tokens = max([token["id"] for token in tokenizer["added_tokens"]])
+            max_tokens = max([token_id for token_id in tokenizer["model"]["vocab"].values()])
+            return max(max_added_tokens, max_tokens)
+        raise NotImplementedError("Vocabulary size could not be determined.")
 
     @property
     def encoder_layer_prefix(self):
@@ -471,7 +513,7 @@ def build_config_dict(hf):
         "hidden_size": config.get("hidden_size", config.get("n_embd", config.get("hidden_dim", config.get("d_model")))),
         "heads": config.get(
             "num_attention_heads",
-            config.get("n_head", config.get("n_heads", config.get("decoder_attention_heads", 32))),
+            config.get("n_head", config.get("n_heads", config.get("decoder_attention_heads", None))),
         ),  # default 32 patch for mistral-community/pixtral-12b
         "transformer_ff": config.get("intermediate_size", config.get("decoder_ffn_dim", None)),
         "mlp_activation_fn": ACT_TABLE[arch],
@@ -504,6 +546,74 @@ def build_config_dict(hf):
         },
         "embeddings": {},  # Populated later
     }
+
+    # Vision encoder
+    if arch == "LlavaForConditionalGeneration":
+        # TODO: extend to other Llava models (with CLIP vision encoder)
+        model_config["encoder"] = {
+            "mlp_activation_fn": model_config["mlp_activation_fn"],
+            "layer_norm": model_config["layer_norm"],
+            "norm_eps": model_config["norm_eps"],
+            "hidden_size": vision_config["image_size"],
+            "transformer_ff": vision_config["image_size"] * 4,  # hard-coded for mistral-community/pixtral-12b
+            "num_channels": 3,
+            "image_size": vision_config["image_size"],
+            "patch_size": vision_config["patch_size"],
+            "rope_config": {
+                "rotary_theta": vision_config["rope_theta"],
+                "rotary_interleave": False,
+            },
+            "layers": 24,  # hard-coded for mistral-community/pixtral-12b
+            "heads": vision_config["image_size"] / vision_config["head_dim"],
+            "heads_kv": vision_config["image_size"] / vision_config["head_dim"],
+            "head_dim": vision_config["head_dim"],
+            "image_token_id": 10,
+        }
+
+    if arch == "Gemma3ForConditionalGeneration":
+        if model_config.get("head_dim", None) is None:
+            model_config["head_dim"] = 256 # https://github.com/huggingface/transformers/blob/7652804d237fb8768f0f0b8129a05e4f0576114b/src/transformers/models/gemma3/configuration_gemma3.py#L61
+        if model_config.get("heads_kv", None) is None:
+            model_config["heads_kv"] = 4
+        if model_config.get("heads", None) is None:
+            model_config["heads"] = 8
+        model_config["adapter"] = "gemma3"
+        # for decoder
+        model_config["decoder"] = {
+            "query_norm": True,
+            "key_norm": True,
+            "rope_config": {
+                "rotary_theta": 1000000,
+                "scaling_type": "gemma3",
+                "rotary_interleave": False,
+                # "scaling_factor": 8.0, # TODO: handle via config
+            },
+        }
+        model_config["encoder"] = {
+            "mlp_activation_fn": "gelu-tanh", # no up_proj it seems
+            "layers": vision_config["num_hidden_layers"],
+            "image_size": vision_config["image_size"],
+            "patch_size": vision_config["patch_size"],
+            "hidden_size": vision_config["hidden_size"],
+            "transformer_ff": vision_config["intermediate_size"],
+            "position_encoding_type": "Learned",
+            "n_positions": (vision_config["image_size"] // vision_config["patch_size"]) ** 2,
+            # head related stuff patched to match 1152 dim of siglip
+            # https://github.com/huggingface/transformers/blob/071a161d3e38f56dbda2743b979f0afeed2cd4f1/src/transformers/models/siglip/modeling_siglip.py#L381-L383
+            "heads": vision_config["num_attention_heads"],
+            "heads_kv": vision_config["num_attention_heads"],
+            "head_dim": 72,
+            "layer_norm": "standard",
+            "add_ffnbias": True,
+            "add_final_linear_bias": True,
+            "add_qkvbias": True,
+            "mm_tokens_per_image": hf.config["mm_tokens_per_image"],
+            "image_token_id": 262144,
+        }
+
+    # TODO: patch this for various models
+    if model_config.get("heads", None) is None:
+        model_config["heads"] = 32
 
     # patch transformer_ff
     if model_config["transformer_ff"] is None:
@@ -647,6 +757,10 @@ def build_config_dict(hf):
                 "normalize": True,
             },
         },
+        "Gemma3ForConditionalGeneration": {
+            "ffn_layernorm": True,
+            "share_decoder_embeddings": True,
+        },
         "M2M100ForConditionalGeneration": {
             "parallel_residual": False,
             "add_qkvbias": True,
@@ -660,29 +774,6 @@ def build_config_dict(hf):
             "share_decoder_embeddings": True,
         },
     }
-
-    # Vision encoder
-    if arch == "LlavaForConditionalGeneration":
-        # TODO: extend to other Llava models (with CLIP vision encoder)
-        model_config["encoder"] = {
-            "mlp_activation_fn": model_config["mlp_activation_fn"],
-            "layer_norm": model_config["layer_norm"],
-            "norm_eps": model_config["norm_eps"],
-            "hidden_size": vision_config["image_size"],
-            "transformer_ff": vision_config["image_size"] * 4,  # hard-coded for mistral-community/pixtral-12b
-            "num_channels": 3,
-            "image_size": vision_config["image_size"],
-            "patch_size": vision_config["patch_size"],
-            "rope_config": {
-                "rotary_theta": vision_config["rope_theta"],
-                "rotary_interleave": False,
-            },
-            "layers": 24,  # hard-coded for mistral-community/pixtral-12b
-            "heads": vision_config["image_size"] / vision_config["head_dim"],
-            "heads_kv": vision_config["image_size"] / vision_config["head_dim"],
-            "head_dim": vision_config["head_dim"],
-            "image_token_id": 10,
-        }
 
     # Update model_config based on architecture
     if arch in arch_configs:
@@ -840,11 +931,16 @@ def build_shards(model_config, hf, args, params):
             "encoder.layer_norm.bias",
             "generator.weight",
             "encoder.patch_conv.weight",
+            "encoder.patch_conv.bias",
             "encoder.ln_pre.weight",
             "adapter.w_in.weight",
             "adapter.w_in.bias",
             "adapter.w_out.weight",
             "adapter.w_out.bias",
+            "adapter.norm.weight",
+            "encoder.position_embeddings.weight",
+            "encoder.post_layernorm.weight",
+            "encoder.post_layernorm.bias"
         ]
 
         def build_first_shard(hf, eole_safetensor):
@@ -853,15 +949,25 @@ def build_shards(model_config, hf, args, params):
             for target in first_shard_targets:
                 if target in KEY_MAPS[hf.arch].keys():
                     source = KEY_MAPS[hf.arch][target]
+                    srckey, srcmap = source if isinstance(source, tuple) else (source, None)
                     if hf.wmap_path:
                         checkpoint = hf.get_load_ckpt(
                             hf.base_dir,
-                            hf.wmap["weight_map"][source],
+                            hf.wmap["weight_map"][srckey],
                         )
                     else:
                         checkpoint = hf.get_load_ckpt(*os.path.split(hf.model_path))
-                    w = get_weight(checkpoint, source)
+                    w = get_weight(checkpoint, srckey)
                     if w is not None:
+                        if srcmap is not None:
+                            w = eval(
+                                "w" + srcmap,
+                                {
+                                    "w": w,
+                                    "hidden_size": model_config["hidden_size"],
+                                    "transformer_ff": model_config["transformer_ff"],
+                                },
+                            ).contiguous()
                         eole_safetensor[target] = w
 
                     if target == "generator.bias":

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -226,6 +226,12 @@ class TransformerConfig(Config):
         "Note: this will add bias to output projection layer too by default. "
         "Can be disabled with `add_final_linear_bias`.",
     )
+    query_norm: bool = Field(
+        default=False,
+    )
+    key_norm: bool = Field(
+        default=False,
+    )
     add_final_linear_bias: bool = Field(default=False, description="Add bias to nn.Linear of final_linear in MHA.")
     heads_kv: int | None = Field(
         default=None,
@@ -343,7 +349,8 @@ class VisionEncoderConfig(TransformerConfig, EncoderConfig):
     num_channels: int | None = 3
     image_size: int | None = 1024
     patch_size: int | None = 16
-    image_token_id: int | None = 10
+    image_token_id: int | None = 10 # pixtral uses 10, gemma3 uses 262144
+    mm_tokens_per_image: int | None = 256 # added for gemma3
 
 
 # use Field with default= + description would be more readable
@@ -711,6 +718,10 @@ class TransformerLMModelConfig(TransformerConfig, BaseModelConfig):
 
 class VisionTransformerLMModelConfig(TransformerConfig, BaseModelConfig):
     architecture: Literal["vision_transformer_lm"] = Field(default="vision_transformer_lm")
+
+    adapter: str | None = Field(
+        default="llava",
+        description="Adapter type to use in the model.")
 
     @model_validator(mode="before")
     @classmethod

--- a/eole/constants.py
+++ b/eole/constants.py
@@ -4,6 +4,7 @@ from enum import Enum
 import torch
 from eole.modules.rmsnorm import RMSNorm, GemmaRMSNorm
 import torch.nn.functional as F
+from functools import partial
 
 
 class DefaultTokens(object):
@@ -62,6 +63,8 @@ class ActivationFunction(str, Enum):
     silu = "silu"
     gated_gelu = "gated-gelu"
     gated_silu = "gated-silu"
+    gelu_tanh = "gelu-tanh"
+    gated_gelu_tanh = "gated-gelu-tanh"
 
 
 class TransformType(str, Enum):
@@ -76,6 +79,9 @@ ACTIVATION_FUNCTIONS = {
     ActivationFunction.silu: F.silu,
     ActivationFunction.gated_gelu: F.gelu,
     ActivationFunction.gated_silu: F.silu,
+    ActivationFunction.gelu_tanh: partial(F.gelu, approximate="tanh"),
+    ActivationFunction.gated_gelu_tanh: partial(F.gelu, approximate="tanh"),
+
 }
 
 

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -59,12 +59,14 @@ class TransformerEncoderLayer(nn.Module):
             * layer_out ``(batch_size, src_len, model_dim)``
         """
         norm_layer_in = self.input_layernorm(layer_in)
-        context, _ = self.self_attn(norm_layer_in, attn_mask=~pad_mask, position_embeddings=position_embeddings)
+        context, _ = self.self_attn(norm_layer_in, attn_mask=~pad_mask if pad_mask is not None else None, position_embeddings=position_embeddings)
         if self.dropout_p > 0:
             context = self.dropout(context)
-        ff_in = self.post_attention_layernorm(context + layer_in) if not self.parallel_residual else norm_layer_in
+        residual = layer_in + context
+        ff_in = self.post_attention_layernorm(residual) if not self.parallel_residual else norm_layer_in
         # apply post attention norm and add residual after mlp
-        layer_out = self.mlp(ff_in) + context + layer_in
+        mlp = self.mlp(ff_in)
+        layer_out = layer_in + context + mlp
 
         return layer_out
 

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -9,9 +9,10 @@ import torch.nn as nn
 from typing import Optional
 
 # from eole.modules.multi_headed_attn import SelfMHA
-from eole.modules.rmsnorm import RMSNorm
+from eole.modules.rmsnorm import RMSNorm, GemmaRMSNorm
 from eole.encoders.transformer import TransformerEncoderLayer
 from eole.modules.rope import build_rope
+from eole.constants import PositionEncodingType
 
 
 def position_ids_in_meshgrid(patch_embeds_list, max_width):
@@ -50,18 +51,29 @@ class VisionEncoder(nn.Module):
     def __init__(self, encoder_config, running_config=None):
         super(VisionEncoder, self).__init__()
         self.encoder_config = encoder_config
-        self.rope = build_rope(encoder_config, mode="2d")
+        # make this configurable (e.g. gemma3 learned PE)
+        if encoder_config.position_encoding_type == PositionEncodingType.Learned:
+            self.position_embeddings = nn.Embedding(
+                encoder_config.n_positions,
+                encoder_config.hidden_size,
+            )
+        else:
+            self.rope = build_rope(encoder_config, mode="2d")
         self.patch_conv = nn.Conv2d(
             in_channels=encoder_config.num_channels,
             out_channels=encoder_config.hidden_size,
             kernel_size=encoder_config.patch_size,
             stride=encoder_config.patch_size,
-            bias=False,
+            # bias=False,
+            padding="valid",
         )
-        self.ln_pre = RMSNorm(encoder_config.hidden_size, eps=1e-5)
+        # self.ln_pre = RMSNorm(encoder_config.hidden_size, eps=1e-5)
         self.transformer_layers = torch.nn.ModuleList()
         for _ in range(encoder_config.layers):
             self.transformer_layers.append(TransformerEncoderLayer(encoder_config, running_config=running_config))
+
+        # only for gemma3
+        self.post_layernorm = nn.LayerNorm(encoder_config.hidden_size, eps=encoder_config.norm_eps)
 
         head_dim = encoder_config.hidden_size // encoder_config.heads
         assert head_dim % 2 == 0, "ROPE requires even head_dim"
@@ -99,22 +111,31 @@ class VisionEncoder(nn.Module):
         patch_embeds_list = [self.patch_conv(img.unsqueeze(0).to(dtype)).squeeze(0) for img in images]
 
         # flatten to a single sequence
-        patch_embeds = torch.cat([p.flatten(1).permute(1, 0) for p in patch_embeds_list], dim=0)
-        patch_embeds = self.ln_pre(patch_embeds)
+        # patch_embeds = torch.cat([p.flatten(1).permute(1, 0) for p in patch_embeds_list], dim=0)
+        patch_embeds = torch.cat([p for p in patch_embeds_list], dim=1)
+        # patch_embeds = self.ln_pre(patch_embeds)
         # should probably be handled upstream to have proper batch dim
         patch_embeds = patch_embeds.unsqueeze(0)
+
+        patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 
         # positional embeddings
         positions = position_ids_in_meshgrid(
             patch_embeds_list,
             max_width=self.encoder_config.image_size // self.encoder_config.patch_size,
-        )
-        position_embeddings = self.rope.update(
-            patch_embeds.size(1),
-            step=0,
-            reset=True,
-            positions=positions,
-        )
+        ).to(self.device)
+        #TODO: make this cleaner
+        if hasattr(self, "position_embeddings"):
+            # this is only used for rope
+            position_embeddings = None
+            patch_embeds += self.position_embeddings(positions)
+        else:
+            position_embeddings = self.rope.update(
+                patch_embeds.size(1),
+                step=0,
+                reset=True,
+                positions=positions,
+            )
 
         # pass through Transformer with a block diagonal mask delimiting images
         mask = create_block_diagonal_mask(
@@ -125,9 +146,12 @@ class VisionEncoder(nn.Module):
         mask = ~mask
         out = patch_embeds
         for i, layer in enumerate(self.transformer_layers):
+            mask = None
             out = layer(out, pad_mask=mask, position_embeddings=position_embeddings)
 
-        # remove batch dimension of the single sequence
+        # only for gemma3
+        out = self.post_layernorm(out)
+
         return out
 
 
@@ -141,3 +165,45 @@ class VisionLanguageAdapter(nn.Module):
 
     def forward(self, x):
         return self.w_out(self.gelu(self.w_in(x)))
+
+    @classmethod
+    def from_config(cls, model_config, running_config=None):
+        return cls(
+            in_dim=model_config.encoder.hidden_size,
+            out_dim=model_config.decoder.hidden_size,
+        )
+
+
+class Gemma3MultiModalProjector(nn.Module):
+    # https://github.com/huggingface/transformers/blob/071a161d3e38f56dbda2743b979f0afeed2cd4f1/src/transformers/models/gemma3/modular_gemma3.py#L717
+    def __init__(self, in_dim, out_dim, image_size, patch_size, mm_tokens_per_image):
+        super(Gemma3MultiModalProjector, self).__init__()
+        self.w_in = nn.Linear(in_dim, out_dim, bias=False)
+        self.norm = GemmaRMSNorm(in_dim)
+        self.patches_per_image = int(image_size / patch_size)
+        self.tokens_per_side = int(mm_tokens_per_image ** 0.5)
+        self.kernel_size = self.patches_per_image // self.tokens_per_side
+        self.avg_pool = nn.AvgPool2d(kernel_size=self.kernel_size, stride=self.kernel_size)
+
+    def forward(self, x):
+        batch_size, _, seq_length = x.size()
+        reshaped = x.transpose(1, 2).reshape(batch_size, seq_length, self.patches_per_image, self.patches_per_image).contiguous()
+        pooled = self.avg_pool(reshaped).flatten(2).transpose(1, 2)
+        normed = self.norm(pooled)
+        projected = self.w_in(normed)
+        return projected.type_as(x)
+
+    @classmethod
+    def from_config(cls, model_config, running_config=None):
+        return cls(
+            in_dim=model_config.encoder.hidden_size,
+            out_dim=model_config.decoder.hidden_size,
+            image_size=model_config.encoder.image_size,
+            patch_size=model_config.encoder.patch_size,
+            mm_tokens_per_image=model_config.encoder.mm_tokens_per_image
+        )
+
+str2adapter = {
+    "llava": VisionLanguageAdapter,
+    "gemma3": Gemma3MultiModalProjector,
+}

--- a/eole/inputters/image_utils.py
+++ b/eole/inputters/image_utils.py
@@ -1,6 +1,9 @@
 import numpy as np
 from PIL import Image
-from typing import Tuple
+import PIL
+from typing import Tuple, Optional, Union
+from enum import Enum
+from collections.abc import Collection
 
 """
 Most of this code is borrowed from:
@@ -11,6 +14,10 @@ https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/tokens/
 DATASET_MEAN = (0.48145466, 0.4578275, 0.40821073)  # RGB
 DATASET_STD = (0.26862954, 0.26130258, 0.27577711)  # RGB
 
+
+class ChannelDimension(Enum):
+    FIRST = "channels_first"
+    LAST = "channels_last"
 
 def _convert_to_rgb(image: Image.Image) -> Image.Image:
     """
@@ -26,14 +33,14 @@ def _convert_to_rgb(image: Image.Image) -> Image.Image:
     return white_bg.convert("RGB")
 
 
-def normalize(np_image, mean, std):
-    # np_image = np_image / 255.0
-    assert len(np_image.shape) == 3, f"{np_image.shape=}"
-    assert np_image.shape[2] == len(mean) == len(std), f"{np_image.shape=}, {mean=}, {std=}"
-    mean = np.array(mean, dtype=np_image.dtype)
-    std = np.array(std, dtype=np_image.dtype)
-    image = (np_image - mean) / std
-    return image.transpose(2, 0, 1)
+# def normalize(np_image, mean, std):
+#     # np_image = np_image / 255.0
+#     assert len(np_image.shape) == 3, f"{np_image.shape=}"
+#     assert np_image.shape[2] == len(mean) == len(std), f"{np_image.shape=}, {mean=}, {std=}"
+#     mean = np.array(mean, dtype=np_image.dtype)
+#     std = np.array(std, dtype=np_image.dtype)
+#     image = (np_image - mean) / std
+#     return image.transpose(2, 0, 1)
 
 
 def transform_image(image: Image.Image, new_size: Tuple[int, int]) -> np.ndarray:
@@ -56,12 +63,255 @@ def image_to_num_tokens(img, image_size=1024, image_patch_size=16):
     return width_tokens, height_tokens
 
 
-def process_image(image_path, image_size=1024, image_patch_size=16):
+# def process_image(image_path, image_size=1024, image_patch_size=16):
+#     image = Image.open(image_path)
+#     w, h = image_to_num_tokens(image, image_size=image_size, image_patch_size=image_patch_size)
+#     new_image_size = (w * image_patch_size, h * image_patch_size)
+#     # TODO retrieve from model config / vocab / tokenizer
+#     image_tokens = (["[IMG]"] * w + ["[IMG_BREAK]"]) * h
+#     image_tokens[-1] = "[IMG_END]"
+#     processed_image = transform_image(image, new_image_size)
+#     return {"image": processed_image, "tokens": image_tokens}
+
+
+# GEMMA 3 stuff, to simplify/factorize with previous pixtral code
+
+def resize(
+    image: np.ndarray,
+    size: Tuple[int, int],
+    resample: "PILImageResampling" = None,
+    reducing_gap: Optional[int] = None,
+    data_format: Optional[ChannelDimension] = None,
+    return_numpy: bool = True,
+    input_data_format: Optional[Union[str, ChannelDimension]] = None,
+) -> np.ndarray:
+    """
+    Resizes `image` to `(height, width)` specified by `size` using the PIL library.
+
+    Args:
+        image (`np.ndarray`):
+            The image to resize.
+        size (`Tuple[int, int]`):
+            The size to use for resizing the image.
+        resample (`int`, *optional*, defaults to `PILImageResampling.BILINEAR`):
+            The filter to user for resampling.
+        reducing_gap (`int`, *optional*):
+            Apply optimization by resizing the image in two steps. The bigger `reducing_gap`, the closer the result to
+            the fair resampling. See corresponding Pillow documentation for more details.
+        data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the output image. If unset, will use the inferred format from the input.
+        return_numpy (`bool`, *optional*, defaults to `True`):
+            Whether or not to return the resized image as a numpy array. If False a `PIL.Image.Image` object is
+            returned.
+        input_data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If unset, will use the inferred format from the input.
+
+    Returns:
+        `np.ndarray`: The resized image.
+    """
+    # requires_backends(resize, ["vision"])
+
+    resample = resample if resample is not None else PILImageResampling.BILINEAR
+
+    if not len(size) == 2:
+        raise ValueError("size must have 2 elements")
+
+    # For all transformations, we want to keep the same data format as the input image unless otherwise specified.
+    # The resized image from PIL will always have channels last, so find the input format first.
+    if input_data_format is None:
+        input_data_format = infer_channel_dimension_format(image)
+    data_format = input_data_format if data_format is None else data_format
+
+    # To maintain backwards compatibility with the resizing done in previous image feature extractors, we use
+    # the pillow library to resize the image and then convert back to numpy
+    do_rescale = False
+    if not isinstance(image, PIL.Image.Image):
+        do_rescale = _rescale_for_pil_conversion(image)
+        image = to_pil_image(image, do_rescale=do_rescale, input_data_format=input_data_format)
+    height, width = size
+    # PIL images are in the format (width, height)
+    resized_image = image.resize((width, height), resample=resample, reducing_gap=reducing_gap)
+
+    if return_numpy:
+        resized_image = np.array(resized_image)
+        # If the input image channel dimension was of size 1, then it is dropped when converting to a PIL image
+        # so we need to add it back if necessary.
+        resized_image = np.expand_dims(resized_image, axis=-1) if resized_image.ndim == 2 else resized_image
+        # The image is always in channels last format after converting from a PIL image
+        resized_image = to_channel_dimension_format(
+            resized_image, data_format, input_channel_dim=ChannelDimension.LAST
+        )
+        # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
+        # rescale it back to the original range.
+        resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
+    return resized_image
+
+def rescale(
+    image: np.ndarray,
+    scale: float,
+    data_format: Optional[ChannelDimension] = None,
+    dtype: np.dtype = np.float32,
+    input_data_format: Optional[Union[str, ChannelDimension]] = None,
+) -> np.ndarray:
+    """
+    Rescales `image` by `scale`.
+
+    Args:
+        image (`np.ndarray`):
+            The image to rescale.
+        scale (`float`):
+            The scale to use for rescaling the image.
+        data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the image. If not provided, it will be the same as the input image.
+        dtype (`np.dtype`, *optional*, defaults to `np.float32`):
+            The dtype of the output image. Defaults to `np.float32`. Used for backwards compatibility with feature
+            extractors.
+        input_data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If not provided, it will be inferred from the input image.
+
+    Returns:
+        `np.ndarray`: The rescaled image.
+    """
+    if not isinstance(image, np.ndarray):
+        raise TypeError(f"Input image must be of type np.ndarray, got {type(image)}")
+
+    rescaled_image = image.astype(np.float64) * scale  # Numpy type promotion has changed, so always upcast first
+    if data_format is not None:
+        rescaled_image = to_channel_dimension_format(rescaled_image, data_format, input_data_format)
+
+    rescaled_image = rescaled_image.astype(dtype)  # Finally downcast to the desired dtype at the end
+
+    return rescaled_image
+
+def get_channel_dimension_axis(
+    image: np.ndarray, input_data_format: Optional[Union[ChannelDimension, str]] = None
+) -> int:
+    """
+    Returns the channel dimension axis of the image.
+
+    Args:
+        image (`np.ndarray`):
+            The image to get the channel dimension axis of.
+        input_data_format (`ChannelDimension` or `str`, *optional*):
+            The channel dimension format of the image. If `None`, will infer the channel dimension from the image.
+
+    Returns:
+        The channel dimension axis of the image.
+    """
+    if input_data_format is None:
+        input_data_format = infer_channel_dimension_format(image)
+    if input_data_format == ChannelDimension.FIRST:
+        return image.ndim - 3
+    elif input_data_format == ChannelDimension.LAST:
+        return image.ndim - 1
+    raise ValueError(f"Unsupported data format: {input_data_format}")
+
+def normalize(
+    image: np.ndarray,
+    mean: Union[float, Collection[float]],
+    std: Union[float, Collection[float]],
+    data_format: Optional[ChannelDimension] = None,
+    input_data_format: Optional[Union[str, ChannelDimension]] = None,
+) -> np.ndarray:
+    """
+    Normalizes `image` using the mean and standard deviation specified by `mean` and `std`.
+
+    image = (image - mean) / std
+
+    Args:
+        image (`np.ndarray`):
+            The image to normalize.
+        mean (`float` or `Collection[float]`):
+            The mean to use for normalization.
+        std (`float` or `Collection[float]`):
+            The standard deviation to use for normalization.
+        data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the output image. If unset, will use the inferred format from the input.
+        input_data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If unset, will use the inferred format from the input.
+    """
+    if not isinstance(image, np.ndarray):
+        raise ValueError("image must be a numpy array")
+
+    if input_data_format is None:
+        input_data_format = infer_channel_dimension_format(image)
+
+    channel_axis = get_channel_dimension_axis(image, input_data_format=input_data_format)
+    num_channels = image.shape[channel_axis]
+
+    # We cast to float32 to avoid errors that can occur when subtracting uint8 values.
+    # We preserve the original dtype if it is a float type to prevent upcasting float16.
+    if not np.issubdtype(image.dtype, np.floating):
+        image = image.astype(np.float32)
+
+    if isinstance(mean, Collection):
+        if len(mean) != num_channels:
+            raise ValueError(f"mean must have {num_channels} elements if it is an iterable, got {len(mean)}")
+    else:
+        mean = [mean] * num_channels
+    mean = np.array(mean, dtype=image.dtype)
+
+    if isinstance(std, Collection):
+        if len(std) != num_channels:
+            raise ValueError(f"std must have {num_channels} elements if it is an iterable, got {len(std)}")
+    else:
+        std = [std] * num_channels
+    std = np.array(std, dtype=image.dtype)
+
+    if input_data_format == ChannelDimension.LAST:
+        image = (image - mean) / std
+    else:
+        image = ((image.T - mean) / std).T
+
+    image = to_channel_dimension_format(image, data_format, input_data_format) if data_format is not None else image
+    return image
+
+def to_channel_dimension_format(
+    image: np.ndarray,
+    channel_dim: Union[ChannelDimension, str],
+    input_channel_dim: Optional[Union[ChannelDimension, str]] = None,
+) -> np.ndarray:
+    """
+    Converts `image` to the channel dimension format specified by `channel_dim`.
+
+    Args:
+        image (`numpy.ndarray`):
+            The image to have its channel dimension set.
+        channel_dim (`ChannelDimension`):
+            The channel dimension format to use.
+        input_channel_dim (`ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If not provided, it will be inferred from the input image.
+
+    Returns:
+        `np.ndarray`: The image with the channel dimension set to `channel_dim`.
+    """
+    if not isinstance(image, np.ndarray):
+        raise TypeError(f"Input image must be of type np.ndarray, got {type(image)}")
+
+    if input_channel_dim is None:
+        input_channel_dim = infer_channel_dimension_format(image)
+
+    target_channel_dim = ChannelDimension(channel_dim)
+    if input_channel_dim == target_channel_dim:
+        return image
+
+    if target_channel_dim == ChannelDimension.FIRST:
+        image = image.transpose((2, 0, 1))
+    elif target_channel_dim == ChannelDimension.LAST:
+        image = image.transpose((1, 2, 0))
+    else:
+        raise ValueError("Unsupported channel dimension format: {}".format(channel_dim))
+
+    return image
+
+def process_image(image_path):
+    # hard coded for gemma 3
     image = Image.open(image_path)
-    w, h = image_to_num_tokens(image, image_size=image_size, image_patch_size=image_patch_size)
-    new_image_size = (w * image_patch_size, h * image_patch_size)
-    # TODO retrieve from model config / vocab / tokenizer
-    image_tokens = (["[IMG]"] * w + ["[IMG_BREAK]"]) * h
-    image_tokens[-1] = "[IMG_END]"
-    processed_image = transform_image(image, new_image_size)
-    return {"image": processed_image, "tokens": image_tokens}
+    image = resize(image=image, size=(896, 896), resample=2, input_data_format=ChannelDimension.LAST)
+    image = rescale(image=image, scale=0.00392156862745098, input_data_format=ChannelDimension.LAST) # 1/256
+    image = normalize(image=image, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], input_data_format=ChannelDimension.LAST)
+    image = to_channel_dimension_format(image, ChannelDimension.FIRST, input_channel_dim=ChannelDimension.LAST)
+    # return image
+    # TODO: make this configurable?
+    image_tokens = "\n\n<start_of_image>" + "<image_soft_token>" * 256 + "<end_of_image>\n\n"
+    return {"image": image, "tokens": image_tokens}

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -25,6 +25,7 @@ from eole.modules.embeddings import Embeddings
 from eole.models.model_saver import load_checkpoint
 from eole.modules.estimator import FeedForward
 
+from eole.encoders.vision import str2adapter
 from eole.encoders.vision import VisionLanguageAdapter, VisionEncoder
 
 
@@ -37,6 +38,14 @@ def build_encoder(model_config, running_config=None):
     enc_type = model_config.encoder.encoder_type
     return str2enc[enc_type].from_config(model_config.encoder, running_config=running_config)  # full config for now
 
+
+def build_adapter(model_config, running_config=None):
+    """
+    Various adapter dispatcher function.
+    """
+    adapter_type = model_config.adapter
+    # print("ADAPTER_TYPE:", adapter_type)
+    return str2adapter[adapter_type].from_config(model_config, running_config=running_config)
 
 def build_decoder(model_config, running_config=None, with_cross_attn=False):
     """
@@ -83,11 +92,13 @@ def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=Fa
         position_shift=model_config.embeddings.position_shift,
         dropout=getattr(running_config, "dropout", [0.0])[0],
         word_padding_idx=vocabs["tgt"][pad_token],
-        word_vocab_size=len(vocabs["tgt"]),
+        # word_vocab_size=len(vocabs["tgt"]),
+        word_vocab_size=262208, # hardcoded for gemma3 test
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_dec,
         n_positions=model_config.embeddings.n_positions,
         normalize=model_config.embeddings.normalize,
+        embed_scale=model_config.hidden_size ** 0.5, # hardcoded for gemma3, to add in config
     )
 
     if share_embeddings:
@@ -532,7 +543,10 @@ class BaseModel(nn.Module):
         else:
             assert (
                 param.data.size() == ckpt_t[col_slice_start:col_slice_end].size()
-            ), "An error in model's partition and checkpoint's slice was detected"
+            ), (
+                "An error in model's partition and checkpoint's slice was detected, "
+                f"[{name}, {module}, {param_name}, {param.data.size()}, {ckpt_t.size()}]"
+            )
             if name + "." + param_name in buf_list:
                 module.register_buffer(param_name, ckpt_t[col_slice_start:col_slice_end].contiguous())
             else:
@@ -896,7 +910,7 @@ class VisionEncoderDecoderModel(BaseModel):
     @classmethod
     def build_blocks(cls, model_config, vocabs, running_config=None):
         encoder = build_encoder(model_config, running_config=running_config)
-        adapter = VisionLanguageAdapter(model_config.encoder.hidden_size, model_config.decoder.hidden_size)
+        adapter = build_adapter(model_config, running_config=running_config)
         tgt_emb = build_tgt_emb(
             model_config,
             vocabs,

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -94,6 +94,7 @@ class Embeddings(nn.Module):
         freeze_word_vecs=False,
         n_positions=1024,
         normalize=False,
+        embed_scale=1.0,
     ):
         super(Embeddings, self).__init__()
         self._validate_args()
@@ -131,6 +132,8 @@ class Embeddings(nn.Module):
 
         if freeze_word_vecs:
             self.embeddings.weight.requires_grad = False
+
+        self.embed_scale = embed_scale
 
     def _validate_args(
         self,
@@ -190,6 +193,8 @@ class Embeddings(nn.Module):
         if self.normalize:
             normalizer = torch.tensor(self.word_vec_size**0.5, dtype=emb.dtype)
             emb = emb * normalizer
+
+        emb = emb * self.embed_scale
 
         if self.dropout_p > 0:
             return self.dropout(emb)

--- a/eole/modules/rmsnorm.py
+++ b/eole/modules/rmsnorm.py
@@ -55,3 +55,6 @@ class RMSNorm(torch.nn.Module):
 class GemmaRMSNorm(RMSNorm):
     def forward(self, hidden_states):
         return self._forward(hidden_states, residual=True)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.eps}"

--- a/eole/modules/transformer_mlp.py
+++ b/eole/modules/transformer_mlp.py
@@ -49,7 +49,7 @@ class MLP(nn.Module):
                 out_features=model_config.transformer_ff // self.parallel_gpu,
                 bias=model_config.add_ffnbias,
             )
-            if model_config.mlp_activation_fn in ["gated-silu", "gated-gelu"]
+            if model_config.mlp_activation_fn in ["gated-silu", "gated-gelu", "gated-gelu-tanh"]
             else None
         )
 

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -639,6 +639,7 @@ class Inference(object):
             src_pad_mask=src_pad_mask,
             tgt_pad_mask=tgt_pad_mask,
             left_pad=left_pad,
+            decoder_in=decoder_in,
         )
         # Generator forward.
         if "std" in dec_attn:

--- a/recipes/gemma3/test_inference.py
+++ b/recipes/gemma3/test_inference.py
@@ -1,0 +1,98 @@
+# flake8: noqa
+
+from rich import print
+from eole.config.run import *
+from eole.inference_engine import InferenceEnginePY
+
+config = PredictConfig(
+    model_path="./gemma-3-4b-pt",
+    src="dummy",
+    # max_length=500,
+    max_length=20,
+    gpu_ranks=[0],
+    # quant_type="bnb_NF4",
+    # quant_type="bnb_FP4",  # HF default, using it for initial reproducibility checks
+    # quant_layers=[
+    #     "gate_up_proj",
+    #     "down_proj",
+    #     "up_proj",
+    #     "linear_values",
+    #     "linear_query",
+    #     "linear_keys",
+    #     "final_linear",
+    #     "w_in",
+    #     "w_out",
+    # ],
+    compute_dtype="bf16",
+    # top_p=0.8,
+    # temperature=0.35,
+    # beam_size=1,
+    seed=42,
+    batch_size=1,
+    batch_type="sents",
+)
+
+print(config)
+
+config.data_type = "image"
+engine = InferenceEnginePY(config)
+
+print(engine.predictor.model)
+engine.predictor.model.count_parameters()
+
+test_input = [
+    {
+        "text": "{image1} in this image, there is",
+        "images": {"image1": "./bee.jpg"},
+    }
+    # {
+    #     "text": "<s>[INST]List the top 5 countries in Europe with the highest GDP\n{image1}[/INST]",
+    #     "images": {"image1": "./test_data/gdp.png"},
+    # },
+    # {
+    #     "text": "[INST]When did things start to go wrong for dark dragon?\n{image1}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/loss_curve.jpg"
+    #     }
+    # },
+    # {
+    #     "text": "<s>[INST]Is this person really big, or is this building just super small?\n{image1}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/pisa_2.jpg"
+    #     }
+    # },
+    # {
+    #     "text": "<s>[INST]Combine information in both the tables into a single markdown table\n{image1}\n{image2}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/table1.png",
+    #         "image2": "./test_data/table2.png"
+    #     }
+    # },
+    # {
+    #     "text": "<s>[INST]Combine information in both the tables into a single markdown table\n{image1}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/multi-images.png"
+    #     }
+    # },
+    # {
+    #     "text": "<s>[INST]Describe the images.\n{image1}\n{image2}\n{image3}\n{image4}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/image1.png",
+    #         "image2": "./test_data/image2.png",
+    #         "image3": "./test_data/image3.png",
+    #         "image4": "./test_data/image4.png",
+    #     }
+    # },
+    # {
+    #     "text": "<s>[INST]Combine information in both the tables into a single markdown table\n{image1}{image2}[/INST]",
+    #     "images": {
+    #         "image1": "./test_data/table1.png",
+    #         "image2": "./test_data/table2.png"
+    #     }
+    # },
+]
+
+pred = engine.infer_list(test_input)
+
+print(pred)
+print(pred[2][0][0].replace("｟newline｠", "\n"))


### PR DESCRIPTION
For the sake of the exercise, and to keep building on recently added vision capacities, I started diving into the Gemma3 implementation.
Though the architecture is not overly different from others, many minor modifications are required here and there, making compatibility not trivial, especially while minimizing duplicated code.
Some of these topics are:
- interleaving local/global attention (one layer out of 6 uses local attention with sliding windows) -- probably not fully working right now;
- image masking;
- siglip-style vision encoder;
- layernom of query/keys before computing SDPA;
- etc.

This branch is not intended to be merged for now, as it breaks several things and has some hard-coded changes for gemma3, but should be a good starting point to keep iterating and homogenizing the vision workflow.

Some slight implementation differences remain, but outputs start to make sense. Only tested with the 4b version for now.