### PR TITLE
Gemma3

### DIFF
--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -608,7 +608,9 @@ def build_config_dict(hf):
 
     if arch == "Gemma3ForConditionalGeneration":
         if model_config.get("head_dim", None) is None:
-            model_config["head_dim"] = 256 # https://github.com/huggingface/transformers/blob/7652804d237fb8768f0f0b8129a05e4f0576114b/src/transformers/models/gemma3/configuration_gemma3.py#L61
+            model_config["head_dim"] = (
+                256  # https://github.com/huggingface/transformers/blob/7652804d237fb8768f0f0b8129a05e4f0576114b/src/transformers/models/gemma3/configuration_gemma3.py#L61
+            )
         if model_config.get("heads_kv", None) is None:
             model_config["heads_kv"] = 4
         if model_config.get("heads", None) is None:
@@ -626,7 +628,7 @@ def build_config_dict(hf):
             },
         }
         model_config["encoder"] = {
-            "mlp_activation_fn": "gelu-tanh", # no up_proj it seems
+            "mlp_activation_fn": "gelu-tanh",  # no up_proj it seems
             "layers": vision_config["num_hidden_layers"],
             "image_size": vision_config["image_size"],
             "patch_size": vision_config["patch_size"],
@@ -1009,7 +1011,7 @@ def build_shards(model_config, hf, args, params):
             "adapter.norm.weight",
             "encoder.position_embeddings.weight",
             "encoder.post_layernorm.weight",
-            "encoder.post_layernorm.bias"
+            "encoder.post_layernorm.bias",
         ]
 
         def build_first_shard(hf, eole_safetensor):

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -586,7 +586,6 @@ def build_config_dict(hf):
 
     # Vision encoder
     if arch in ["LlavaForConditionalGeneration", "Mistral3ForConditionalGeneration"]:
-        # TODO: extend to other Llava models (with CLIP vision encoder)
         model_config["encoder"] = {
             "mlp_activation_fn": model_config["mlp_activation_fn"],
             "layer_norm": model_config["layer_norm"],
@@ -651,14 +650,14 @@ def build_config_dict(hf):
             # https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L399-L402
             "heads": vision_config["num_attention_heads"],
             "heads_kv": vision_config["num_attention_heads"],
-            "head_dim": 72,
+            "head_dim": vision_config["hidden_size"] // vision_config["num_attention_heads"],
             "layer_norm": "standard",
             "add_ffnbias": True,
             "add_final_linear_bias": True,
             "add_qkvbias": True,
             "mm_tokens_per_image": hf.config["mm_tokens_per_image"],
-            "image_token_id": 262144,
-            "layernorm_pre": False,
+            "image_token_id": hf.config["image_token_index"],
+            "layernorm_pre": False,  # implies post layernorm
             "patch_conv_bias": True,
         }
 

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -809,8 +809,11 @@ def build_config_dict(hf):
             },
         },
         "Gemma3ForConditionalGeneration": {
-            "ffn_layernorm": True,
             "share_decoder_embeddings": True,
+            "ffn_layernorm": True,
+            "embeddings": {
+                "normalize": True,
+            },
         },
         "M2M100ForConditionalGeneration": {
             "parallel_residual": False,

--- a/eole/bin/convert/convert_HF.py
+++ b/eole/bin/convert/convert_HF.py
@@ -608,9 +608,7 @@ def build_config_dict(hf):
 
     if arch == "Gemma3ForConditionalGeneration":
         if model_config.get("head_dim", None) is None:
-            model_config["head_dim"] = (
-                256  # https://github.com/huggingface/transformers/blob/7652804d237fb8768f0f0b8129a05e4f0576114b/src/transformers/models/gemma3/configuration_gemma3.py#L61
-            )
+            model_config["head_dim"] = 256  # src/transformers/models/gemma3/configuration_gemma3.py#L61
         if model_config.get("heads_kv", None) is None:
             model_config["heads_kv"] = 4
         if model_config.get("heads", None) is None:
@@ -637,7 +635,7 @@ def build_config_dict(hf):
             "position_encoding_type": "Learned",
             "n_positions": (vision_config["image_size"] // vision_config["patch_size"]) ** 2,
             # head related stuff patched to match 1152 dim of siglip
-            # https://github.com/huggingface/transformers/blob/071a161d3e38f56dbda2743b979f0afeed2cd4f1/src/transformers/models/siglip/modeling_siglip.py#L381-L383
+            # https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L399-L402
             "heads": vision_config["num_attention_heads"],
             "heads_kv": vision_config["num_attention_heads"],
             "head_dim": 72,

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -348,8 +348,8 @@ class VisionEncoderConfig(TransformerConfig, EncoderConfig):
     num_channels: int | None = 3
     image_size: int | None = 1024
     patch_size: int | None = 16
-    image_token_id: int | None = 10 # pixtral uses 10, gemma3 uses 262144
-    mm_tokens_per_image: int | None = 256 # added for gemma3
+    image_token_id: int | None = 10  # pixtral uses 10, gemma3 uses 262144
+    mm_tokens_per_image: int | None = 256  # added for gemma3
 
 
 # use Field with default= + description would be more readable
@@ -740,9 +740,7 @@ class TransformerLMModelConfig(TransformerConfig, BaseModelConfig):
 class VisionTransformerLMModelConfig(TransformerConfig, BaseModelConfig):
     architecture: Literal["vision_transformer_lm"] = Field(default="vision_transformer_lm")
 
-    adapter: str | None = Field(
-        default="llava",
-        description="Adapter type to use in the model.")
+    adapter: str | None = Field(default="llava", description="Adapter type to use in the model.")
 
     @model_validator(mode="before")
     @classmethod

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -182,6 +182,18 @@ class RotaryPositionConfig(Config):
         default=8192,
         description="Original maximum position embeddings for RoPE scaling.",
     )
+    rotary_theta_local: int = Field(
+        default=10000,
+        description="Rotary theta base length for local rotary layers",
+    )
+    interleave_local: int = Field(
+        default=0,
+        description="Local rotary layers each 1/N layers",
+    )
+    tmax_index: int = Field(
+        default=0,
+        description="tmax indexing, 0 for all cases except gemma 3 = 1",
+    )
 
 
 class TransformerConfig(Config):
@@ -350,6 +362,8 @@ class VisionEncoderConfig(TransformerConfig, EncoderConfig):
     patch_size: int | None = 16
     image_token_id: int | None = 10  # pixtral uses 10, gemma3 uses 262144
     mm_tokens_per_image: int | None = 256  # added for gemma3
+    layernorm_pre: bool = True  # True for pixtral/mistral False for gemma3
+    patch_conv_bias: bool = False  # False for pixtral/mistral True for gemma3
 
 
 # use Field with default= + description would be more readable
@@ -677,11 +691,11 @@ class TransformerModelConfig(TransformerConfig, BaseModelConfig):
         if not (isinstance(data, dict)):
             return data
         if "encoder" in data.keys():
-            data["encoder"]["encoder_type"] = "transformer"
+            data["encoder"].encoder_type = "transformer"
         else:
             data["encoder"] = {"encoder_type": "transformer"}
         if "decoder" in data.keys():
-            data["decoder"]["decoder_type"] = "transformer"
+            data["decoder"].decoder_type = "transformer"
         else:
             data["decoder"] = {"decoder_type": "transformer"}
         return data

--- a/eole/constants.py
+++ b/eole/constants.py
@@ -81,7 +81,6 @@ ACTIVATION_FUNCTIONS = {
     ActivationFunction.gated_silu: F.silu,
     ActivationFunction.gelu_tanh: partial(F.gelu, approximate="tanh"),
     ActivationFunction.gated_gelu_tanh: partial(F.gelu, approximate="tanh"),
-
 }
 
 

--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -334,6 +334,7 @@ class TransformerDecoder(DecoderBase):
                 attn_mask = None
 
         # we need to adapt the mask for gemma3, TODO: find another condition?
+        # SEEMS OK TO MASK IMAGES FOR LLAVA TOO ?
         if decoder_in is not None and attn_mask is not None:
             attn_mask = self._update_causal_mask(attn_mask, decoder_in == image_token_id)
 

--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -21,13 +21,7 @@ class TransformerDecoderLayer(nn.Module):
         with_cross_attn (True when used with an encoder)
     """
 
-    def __init__(
-        self,
-        decoder_config,
-        running_config=None,
-        with_cross_attn=False,
-        layer_index=None
-    ):
+    def __init__(self, decoder_config, running_config=None, with_cross_attn=False, layer_index=None):
         super(TransformerDecoderLayer, self).__init__()
         self.parallel_residual = decoder_config.parallel_residual
         self.shared_layer_norm = decoder_config.shared_layer_norm
@@ -272,7 +266,7 @@ class TransformerDecoder(DecoderBase):
         return attn_mask.unsqueeze(1)  # (batch x 1 x 1 x tgt_len)
 
     def _update_causal_mask(self, attn_mask, decoder_in):
-        image_locations = decoder_in == 262144 # TODO: grab from config/kwargs
+        image_locations = decoder_in == 262144  # TODO: grab from config/kwargs
         # replicating HF code, can probably be simplified
         token_type_ids = torch.where(image_locations, torch.tensor(1), torch.tensor(0))
         token_type_mask = token_type_ids.unsqueeze(1) == token_type_ids.unsqueeze(2)
@@ -347,7 +341,9 @@ class TransformerDecoder(DecoderBase):
                 attn_mask=attn_mask,
                 step=step,
                 return_attn=return_attn,
-                position_embeddings=position_embeddings_local if i+1 % 6 else position_embeddings, # do this only for gemma3
+                position_embeddings=(
+                    position_embeddings_local if i + 1 % 6 else position_embeddings
+                ),  # do this only for gemma3
             )
             if with_align:
                 attn_align = layer.get_attn_align(
@@ -357,7 +353,7 @@ class TransformerDecoder(DecoderBase):
                     attn_mask=~tgt_pad_mask,
                     step=step,
                     return_attn=return_attn,
-                    position_embeddings=position_embeddings_local if i+1 % 6 else position_embeddings,
+                    position_embeddings=position_embeddings_local if i + 1 % 6 else position_embeddings,
                     attns=attn,
                 )
                 if attn_align is not None:

--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -21,7 +21,7 @@ class TransformerDecoderLayer(nn.Module):
         with_cross_attn (True when used with an encoder)
     """
 
-    def __init__(self, decoder_config, running_config=None, with_cross_attn=False, layer_index=None):
+    def __init__(self, decoder_config, running_config=None, with_cross_attn=False):
         super(TransformerDecoderLayer, self).__init__()
         self.parallel_residual = decoder_config.parallel_residual
         self.shared_layer_norm = decoder_config.shared_layer_norm
@@ -348,7 +348,7 @@ class TransformerDecoder(DecoderBase):
                 return_attn=return_attn,
                 position_embeddings=(
                     position_embeddings_local if (i + 1) % self.interleave_local else position_embeddings
-                ),  # do this only for gemma3
+                ),
             )
             if with_align:
                 attn_align = layer.get_attn_align(

--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -207,10 +207,11 @@ class TransformerDecoder(DecoderBase):
         self.with_cross_attn = with_cross_attn
         self.sliding_window = decoder_config.sliding_window
         self.rope = build_rope(decoder_config)
-        # introduced for gemma3, hack to improve
-        decoder_config.rope_config.scaling_type = "none"
-        decoder_config.rope_config.rotary_theta = 10000
-        self.rope_local = build_rope(decoder_config)
+        if hasattr(decoder_config, "rope_config") and getattr(decoder_config.rope_config, "interleave_local", 0) > 0:
+            self.rope_local = build_rope(decoder_config, variant="local")
+        else:
+            self.rope_local = None
+        self.interleave_local = getattr(decoder_config.rope_config, "interleave_local", 0) or 1
         self.transformer_layers = nn.ModuleList(
             [
                 TransformerDecoderLayer(
@@ -265,8 +266,7 @@ class TransformerDecoder(DecoderBase):
         attn_mask = ~tgt_pad_mask & future_mask.unsqueeze(0)
         return attn_mask.unsqueeze(1)  # (batch x 1 x 1 x tgt_len)
 
-    def _update_causal_mask(self, attn_mask, decoder_in):
-        image_locations = decoder_in == 262144  # TODO: grab from config/kwargs
+    def _update_causal_mask(self, attn_mask, image_locations):
         # replicating HF code, can probably be simplified
         token_type_ids = torch.where(image_locations, torch.tensor(1), torch.tensor(0))
         token_type_mask = token_type_ids.unsqueeze(1) == token_type_ids.unsqueeze(2)
@@ -309,8 +309,12 @@ class TransformerDecoder(DecoderBase):
         with_align = kwargs.pop("with_align", False)
         return_attn = with_align or kwargs.pop("return_attn", False)
         position_embeddings = self.rope.update(emb.size(1), step=step)
-        position_embeddings_local = self.rope_local.update(emb.size(1), step=step)
+        if self.rope_local is not None:
+            position_embeddings_local = self.rope_local.update(emb.size(1), step=step)
+        else:
+            position_embeddings_local = position_embeddings
         decoder_in = kwargs.pop("decoder_in", None)
+        image_token_id = kwargs.pop("image_token_id", None)
         attn_aligns = []
 
         if step == 0:
@@ -330,8 +334,8 @@ class TransformerDecoder(DecoderBase):
                 attn_mask = None
 
         # we need to adapt the mask for gemma3, TODO: find another condition?
-        if decoder_in is not None:
-            attn_mask = self._update_causal_mask(attn_mask, decoder_in)
+        if decoder_in is not None and attn_mask is not None:
+            attn_mask = self._update_causal_mask(attn_mask, decoder_in == image_token_id)
 
         for i, layer in enumerate(self.transformer_layers):
             emb, attn = layer(
@@ -342,7 +346,7 @@ class TransformerDecoder(DecoderBase):
                 step=step,
                 return_attn=return_attn,
                 position_embeddings=(
-                    position_embeddings_local if i + 1 % 6 else position_embeddings
+                    position_embeddings_local if (i + 1) % self.interleave_local else position_embeddings
                 ),  # do this only for gemma3
             )
             if with_align:
@@ -353,7 +357,9 @@ class TransformerDecoder(DecoderBase):
                     attn_mask=~tgt_pad_mask,
                     step=step,
                     return_attn=return_attn,
-                    position_embeddings=position_embeddings_local if i + 1 % 6 else position_embeddings,
+                    position_embeddings=(
+                        position_embeddings_local if (i + 1) % self.interleave_local else position_embeddings
+                    ),
                     attns=attn,
                 )
                 if attn_align is not None:

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -59,7 +59,11 @@ class TransformerEncoderLayer(nn.Module):
             * layer_out ``(batch_size, src_len, model_dim)``
         """
         norm_layer_in = self.input_layernorm(layer_in)
-        context, _ = self.self_attn(norm_layer_in, attn_mask=~pad_mask if pad_mask is not None else None, position_embeddings=position_embeddings)
+        context, _ = self.self_attn(
+            norm_layer_in,
+            attn_mask=~pad_mask if pad_mask is not None else None,
+            position_embeddings=position_embeddings,
+        )
         if self.dropout_p > 0:
             context = self.dropout(context)
         residual = layer_in + context

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -156,12 +156,11 @@ class VisionEncoder(nn.Module):
         if self.ln_pre is not None:  # pixtral / mistral
             patch_embeds = torch.cat([p.flatten(1).permute(1, 0) for p in patch_embeds_list], dim=0)
             patch_embeds = self.ln_pre(patch_embeds)
+            patch_embeds = patch_embeds.unsqueeze(0)
         else:  # gemma3
             patch_embeds = torch.cat([p for p in patch_embeds_list], dim=1)
-        # should probably be handled upstream to have proper batch dim
-        patch_embeds = patch_embeds.unsqueeze(0)
-
-        patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
+            patch_embeds = patch_embeds.unsqueeze(0)
+            patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 
         # positional embeddings
         positions = position_ids_in_meshgrid(
@@ -190,7 +189,7 @@ class VisionEncoder(nn.Module):
         mask = ~mask
         out = patch_embeds
         for i, layer in enumerate(self.transformer_layers):
-            mask = None
+            # mask = None
             out = layer(out, pad_mask=mask, position_embeddings=position_embeddings)
 
         if self.post_layernorm is not None:
@@ -224,8 +223,7 @@ class VisionLanguageAdapter(nn.Module):
     @classmethod
     def from_config(cls, model_config, running_config=None):
         return cls(
-            in_dim=model_config.encoder.hidden_size,
-            out_dim=model_config.decoder.hidden_size,
+            model_config,
         )
 
 

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -151,7 +151,7 @@ class VisionEncoder(nn.Module):
         # pass images through initial convolution independently
         patch_embeds_list = [self.patch_conv(img.unsqueeze(0).to(dtype)).squeeze(0) for img in images]
 
-        # flatten to a single sequence
+        # flatten to a single sequence - NEED TO IMPROVE THIS CODE
         if self.ln_pre is not None:  # pixtral / mistral
             patch_embeds = torch.cat([p.flatten(1).permute(1, 0) for p in patch_embeds_list], dim=0)
             patch_embeds = self.ln_pre(patch_embeds)

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -162,7 +162,7 @@ class VisionEncoder(nn.Module):
             patch_embeds_list,
             max_width=self.encoder_config.image_size // self.encoder_config.patch_size,
         ).to(self.device)
-        #TODO: make this cleaner
+        # TODO: make this cleaner
         if hasattr(self, "position_embeddings"):
             # this is only used for rope
             position_embeddings = None
@@ -230,13 +230,17 @@ class Gemma3MultiModalProjector(nn.Module):
         self.w_in = nn.Linear(in_dim, out_dim, bias=False)
         self.norm = GemmaRMSNorm(in_dim)
         self.patches_per_image = int(image_size / patch_size)
-        self.tokens_per_side = int(mm_tokens_per_image ** 0.5)
+        self.tokens_per_side = int(mm_tokens_per_image**0.5)
         self.kernel_size = self.patches_per_image // self.tokens_per_side
         self.avg_pool = nn.AvgPool2d(kernel_size=self.kernel_size, stride=self.kernel_size)
 
     def forward(self, x):
         batch_size, _, seq_length = x.size()
-        reshaped = x.transpose(1, 2).reshape(batch_size, seq_length, self.patches_per_image, self.patches_per_image).contiguous()
+        reshaped = (
+            x.transpose(1, 2)
+            .reshape(batch_size, seq_length, self.patches_per_image, self.patches_per_image)
+            .contiguous()
+        )
         pooled = self.avg_pool(reshaped).flatten(2).transpose(1, 2)
         normed = self.norm(pooled)
         projected = self.w_in(normed)
@@ -249,8 +253,9 @@ class Gemma3MultiModalProjector(nn.Module):
             out_dim=model_config.decoder.hidden_size,
             image_size=model_config.encoder.image_size,
             patch_size=model_config.encoder.patch_size,
-            mm_tokens_per_image=model_config.encoder.mm_tokens_per_image
+            mm_tokens_per_image=model_config.encoder.mm_tokens_per_image,
         )
+
 
 str2adapter = {
     "llava": VisionLanguageAdapter,

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -102,7 +102,6 @@ class VisionEncoder(nn.Module):
             kernel_size=encoder_config.patch_size,
             stride=encoder_config.patch_size,
             bias=encoder_config.patch_conv_bias,
-            padding="valid",
         )
         if encoder_config.layernorm_pre:
             self.ln_pre = RMSNorm(encoder_config.hidden_size, eps=1e-5)
@@ -162,6 +161,7 @@ class VisionEncoder(nn.Module):
             patch_embeds = patch_embeds.unsqueeze(0)
             patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 
+        # At this point patch_embeds is [batch x hiddensize x seq] but batch is fake = 1
         # positional embeddings
         positions = position_ids_in_meshgrid(
             patch_embeds_list,
@@ -189,7 +189,7 @@ class VisionEncoder(nn.Module):
         mask = ~mask
         out = patch_embeds
         for i, layer in enumerate(self.transformer_layers):
-            # mask = None
+            # mask = None # NEEDS CLARIFICATION
             out = layer(out, pad_mask=mask, position_embeddings=position_embeddings)
 
         if self.post_layernorm is not None:

--- a/eole/inputters/dynamic_iterator.py
+++ b/eole/inputters/dynamic_iterator.py
@@ -140,6 +140,7 @@ class DynamicDatasetIter(torch.utils.data.IterableDataset):
         left_pad=False,
         model_type=None,
         image_patch_size=16,
+        adapter=None,
     ):
         super(DynamicDatasetIter).__init__()
         self.corpora = corpora
@@ -173,6 +174,7 @@ class DynamicDatasetIter(torch.utils.data.IterableDataset):
             self.left_pad = False
         self.model_type = model_type
         self.image_patch_size = image_patch_size
+        self.adapter = adapter
 
     @classmethod
     def from_config(
@@ -244,6 +246,7 @@ class DynamicDatasetIter(torch.utils.data.IterableDataset):
             left_pad=getattr(config.model, "left_pad", False),
             model_type=model_type if model_type is not None else getattr(config.model, "model_type", None),
             image_patch_size=image_patch_size,
+            adapter=getattr(config.model, "adapter", None)
         )
 
     def _init_datasets(self, worker_id):
@@ -261,6 +264,7 @@ class DynamicDatasetIter(torch.utils.data.IterableDataset):
             stride=stride,
             offset=offset,
             image_patch_size=self.image_patch_size,
+            adapter=self.adapter,
         )
         datasets_weights = {ds_name: int(self.corpora_info[ds_name].weight) for ds_name in datasets_iterables.keys()}
         if self.task == CorpusTask.TRAIN:

--- a/eole/inputters/dynamic_iterator.py
+++ b/eole/inputters/dynamic_iterator.py
@@ -246,7 +246,7 @@ class DynamicDatasetIter(torch.utils.data.IterableDataset):
             left_pad=getattr(config.model, "left_pad", False),
             model_type=model_type if model_type is not None else getattr(config.model, "model_type", None),
             image_patch_size=image_patch_size,
-            adapter=getattr(config.model, "adapter", None)
+            adapter=getattr(config.model, "adapter", None),
         )
 
     def _init_datasets(self, worker_id):

--- a/eole/inputters/image_utils.py
+++ b/eole/inputters/image_utils.py
@@ -1,12 +1,11 @@
 import torch
 import numpy as np
 from PIL import Image
-from PIL.Image import PILImageResampling
 import PIL
 from typing import Tuple, Optional, Union
 from enum import Enum
 from collections.abc import Collection
-import logger
+from eole.utils.logging import logger
 
 """
 Most of this code is borrowed from:
@@ -201,7 +200,7 @@ def infer_channel_dimension_format(
 def resize(
     image: np.ndarray,
     size: Tuple[int, int],
-    resample: "PILImageResampling" = None,
+    resample: "Image.Resampling" = None,
     reducing_gap: Optional[int] = None,
     data_format: Optional[ChannelDimension] = None,
     return_numpy: bool = True,
@@ -215,7 +214,7 @@ def resize(
             The image to resize.
         size (`Tuple[int, int]`):
             The size to use for resizing the image.
-        resample (`int`, *optional*, defaults to `PILImageResampling.BILINEAR`):
+        resample (`int`, *optional*, defaults to `Image.Resampling.BILINEAR`):
             The filter to user for resampling.
         reducing_gap (`int`, *optional*):
             Apply optimization by resizing the image in two steps. The bigger `reducing_gap`, the closer the result to
@@ -233,7 +232,7 @@ def resize(
     """
     # requires_backends(resize, ["vision"])
 
-    resample = resample if resample is not None else PILImageResampling.BILINEAR
+    resample = resample if resample is not None else Image.Resampling.BILINEAR
 
     if not len(size) == 2:
         raise ValueError("size must have 2 elements")
@@ -429,7 +428,7 @@ def to_channel_dimension_format(
     return image
 
 
-def process_image(image_path):
+def process_image(image_path, image_patch_size=16):
     # hard coded for gemma 3
     image = Image.open(image_path)
     image = resize(image=image, size=(896, 896), resample=2, input_data_format=ChannelDimension.LAST)

--- a/eole/inputters/image_utils.py
+++ b/eole/inputters/image_utils.py
@@ -37,13 +37,13 @@ def _convert_to_rgb(image: Image.Image) -> Image.Image:
 
 
 def normalize_llava(np_image, mean, std):
-     # np_image = np_image / 255.0
-     assert len(np_image.shape) == 3, f"{np_image.shape=}"
-     assert np_image.shape[2] == len(mean) == len(std), f"{np_image.shape=}, {mean=}, {std=}"
-     mean = np.array(mean, dtype=np_image.dtype)
-     std = np.array(std, dtype=np_image.dtype)
-     image = (np_image - mean) / std
-     return image.transpose(2, 0, 1)
+    # np_image = np_image / 255.0
+    assert len(np_image.shape) == 3, f"{np_image.shape=}"
+    assert np_image.shape[2] == len(mean) == len(std), f"{np_image.shape=}, {mean=}, {std=}"
+    mean = np.array(mean, dtype=np_image.dtype)
+    std = np.array(std, dtype=np_image.dtype)
+    image = (np_image - mean) / std
+    return image.transpose(2, 0, 1)
 
 
 def transform_image(image: Image.Image, new_size: Tuple[int, int]) -> np.ndarray:
@@ -423,12 +423,14 @@ def process_image(image_path, adapter="llava", image_size=1024, image_patch_size
         image_tokens = (["[IMG]"] * w + ["[IMG_BREAK]"]) * h
         image_tokens[-1] = "[IMG_END]"
         processed_image = transform_image(image, new_image_size)
-        return {"image": processed_image, "tokens": image_tokens}    
+        return {"image": processed_image, "tokens": image_tokens}
     elif adapter == "gemma3":
         image = Image.open(image_path)
         image = resize(image=image, size=(896, 896), resample=2, input_data_format=ChannelDimension.LAST)
         image = rescale(image=image, scale=0.00392156862745098, input_data_format=ChannelDimension.LAST)  # 1/256
-        image = normalize_gemma(image=image, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], input_data_format=ChannelDimension.LAST)
+        image = normalize_gemma(
+            image=image, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], input_data_format=ChannelDimension.LAST
+        )
         image = to_channel_dimension_format(image, ChannelDimension.FIRST, input_channel_dim=ChannelDimension.LAST)
         # return image
         # TODO: make this configurable?

--- a/eole/inputters/image_utils.py
+++ b/eole/inputters/image_utils.py
@@ -1,9 +1,12 @@
+import torch
 import numpy as np
 from PIL import Image
+from PIL.Image import PILImageResampling
 import PIL
 from typing import Tuple, Optional, Union
 from enum import Enum
 from collections.abc import Collection
+import logger
 
 """
 Most of this code is borrowed from:
@@ -76,6 +79,123 @@ def image_to_num_tokens(img, image_size=1024, image_patch_size=16):
 
 
 # GEMMA 3 stuff, to simplify/factorize with previous pixtral code
+
+
+def _rescale_for_pil_conversion(image):
+    """
+    Detects whether or not the image needs to be rescaled before being converted to a PIL image.
+
+    The assumption is that if the image is of type `np.float` and all values are between 0 and 1, it needs to be
+    rescaled.
+    """
+    if image.dtype == np.uint8:
+        do_rescale = False
+    elif np.allclose(image, image.astype(int)):
+        if np.all(0 <= image) and np.all(image <= 255):
+            do_rescale = False
+        else:
+            raise ValueError(
+                "The image to be converted to a PIL image contains values outside the range [0, 255], "
+                f"got [{image.min()}, {image.max()}] which cannot be converted to uint8."
+            )
+    elif np.all(0 <= image) and np.all(image <= 1):
+        do_rescale = True
+    else:
+        raise ValueError(
+            "The image to be converted to a PIL image contains values outside the range [0, 1], "
+            f"got [{image.min()}, {image.max()}] which cannot be converted to uint8."
+        )
+    return do_rescale
+
+
+def to_pil_image(
+    image: Union[np.ndarray, "PIL.Image.Image", "torch.Tensor"],
+    do_rescale: Optional[bool] = None,
+    image_mode: Optional[str] = None,
+    input_data_format: Optional[Union[str, ChannelDimension]] = None,
+) -> "PIL.Image.Image":
+    """
+    Converts `image` to a PIL Image. Optionally rescales it and puts the channel dimension back as the last axis if
+    needed.
+
+    Args:
+        image (`PIL.Image.Image` or `numpy.ndarray` or `torch.Tensor`):
+            The image to convert to the `PIL.Image` format.
+        do_rescale (`bool`, *optional*):
+            Whether or not to apply the scaling factor (to make pixel values integers between 0 and 255). Will default
+            to `True` if the image type is a floating type and casting to `int` would result in a loss of precision,
+            and `False` otherwise.
+        image_mode (`str`, *optional*):
+            The mode to use for the PIL image. If unset, will use the default mode for the input image type.
+        input_data_format (`ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If unset, will use the inferred format from the input.
+
+    Returns:
+        `PIL.Image.Image`: The converted image.
+    """
+    # requires_backends(to_pil_image, ["vision"])
+
+    if isinstance(image, PIL.Image.Image):
+        return image
+
+    # Convert all tensors to numpy arrays before converting to PIL image
+    if isinstance(image, torch.Tensor):
+        image = image.numpy()
+    elif not isinstance(image, np.ndarray):
+        raise ValueError(f"Input image type not supported: {type(image)}")
+
+    # If the channel has been moved to first dim, we put it back at the end.
+    image = to_channel_dimension_format(image, ChannelDimension.LAST, input_data_format)
+
+    # If there is a single channel, we squeeze it, as otherwise PIL can't handle it.
+    image = np.squeeze(image, axis=-1) if image.shape[-1] == 1 else image
+
+    # PIL.Image can only store uint8 values so we rescale the image to be between 0 and 255 if needed.
+    do_rescale = _rescale_for_pil_conversion(image) if do_rescale is None else do_rescale
+
+    if do_rescale:
+        image = rescale(image, 255)
+
+    image = image.astype(np.uint8)
+    return PIL.Image.fromarray(image, mode=image_mode)
+
+
+def infer_channel_dimension_format(
+    image: np.ndarray, num_channels: Optional[Union[int, tuple[int, ...]]] = None
+) -> ChannelDimension:
+    """
+    Infers the channel dimension format of `image`.
+
+    Args:
+        image (`np.ndarray`):
+            The image to infer the channel dimension of.
+        num_channels (`int` or `Tuple[int, ...]`, *optional*, defaults to `(1, 3)`):
+            The number of channels of the image.
+
+    Returns:
+        The channel dimension of the image.
+    """
+    num_channels = num_channels if num_channels is not None else (1, 3)
+    num_channels = (num_channels,) if isinstance(num_channels, int) else num_channels
+
+    if image.ndim == 3:
+        first_dim, last_dim = 0, 2
+    elif image.ndim == 4:
+        first_dim, last_dim = 1, 3
+    else:
+        raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
+
+    if image.shape[first_dim] in num_channels and image.shape[last_dim] in num_channels:
+        logger.warning(
+            f"The channel dimension is ambiguous. Got image shape {image.shape}."
+            f"Assuming channels are the first dimension."
+        )
+        return ChannelDimension.FIRST
+    elif image.shape[first_dim] in num_channels:
+        return ChannelDimension.FIRST
+    elif image.shape[last_dim] in num_channels:
+        return ChannelDimension.LAST
+    raise ValueError("Unable to infer channel dimension format")
 
 
 def resize(

--- a/eole/inputters/image_utils.py
+++ b/eole/inputters/image_utils.py
@@ -19,6 +19,7 @@ class ChannelDimension(Enum):
     FIRST = "channels_first"
     LAST = "channels_last"
 
+
 def _convert_to_rgb(image: Image.Image) -> Image.Image:
     """
     Convert a PIL image to RGB.
@@ -75,6 +76,7 @@ def image_to_num_tokens(img, image_size=1024, image_patch_size=16):
 
 
 # GEMMA 3 stuff, to simplify/factorize with previous pixtral code
+
 
 def resize(
     image: np.ndarray,
@@ -138,13 +140,12 @@ def resize(
         # so we need to add it back if necessary.
         resized_image = np.expand_dims(resized_image, axis=-1) if resized_image.ndim == 2 else resized_image
         # The image is always in channels last format after converting from a PIL image
-        resized_image = to_channel_dimension_format(
-            resized_image, data_format, input_channel_dim=ChannelDimension.LAST
-        )
+        resized_image = to_channel_dimension_format(resized_image, data_format, input_channel_dim=ChannelDimension.LAST)
         # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
         # rescale it back to the original range.
         resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
     return resized_image
+
 
 def rescale(
     image: np.ndarray,
@@ -183,6 +184,7 @@ def rescale(
 
     return rescaled_image
 
+
 def get_channel_dimension_axis(
     image: np.ndarray, input_data_format: Optional[Union[ChannelDimension, str]] = None
 ) -> int:
@@ -205,6 +207,7 @@ def get_channel_dimension_axis(
     elif input_data_format == ChannelDimension.LAST:
         return image.ndim - 1
     raise ValueError(f"Unsupported data format: {input_data_format}")
+
 
 def normalize(
     image: np.ndarray,
@@ -266,6 +269,7 @@ def normalize(
     image = to_channel_dimension_format(image, data_format, input_data_format) if data_format is not None else image
     return image
 
+
 def to_channel_dimension_format(
     image: np.ndarray,
     channel_dim: Union[ChannelDimension, str],
@@ -304,11 +308,12 @@ def to_channel_dimension_format(
 
     return image
 
+
 def process_image(image_path):
     # hard coded for gemma 3
     image = Image.open(image_path)
     image = resize(image=image, size=(896, 896), resample=2, input_data_format=ChannelDimension.LAST)
-    image = rescale(image=image, scale=0.00392156862745098, input_data_format=ChannelDimension.LAST) # 1/256
+    image = rescale(image=image, scale=0.00392156862745098, input_data_format=ChannelDimension.LAST)  # 1/256
     image = normalize(image=image, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], input_data_format=ChannelDimension.LAST)
     image = to_channel_dimension_format(image, ChannelDimension.FIRST, input_channel_dim=ChannelDimension.LAST)
     # return image

--- a/eole/inputters/text_corpus.py
+++ b/eole/inputters/text_corpus.py
@@ -367,7 +367,7 @@ class ImageTextCorpusIterator(object):
         offset=0,
         is_train=False,
         image_patch_size=16,
-        adapter="llava"
+        adapter="llava",
     ):
         self.cid = corpus.id
         self.corpus = corpus
@@ -412,8 +412,7 @@ class ImageTextCorpusIterator(object):
 
 
 def build_corpora_iters(
-    corpora, transforms, corpora_info, skip_empty_level="warning",
-    stride=1, offset=0, image_patch_size=16, adapter=None
+    corpora, transforms, corpora_info, skip_empty_level="warning", stride=1, offset=0, image_patch_size=16, adapter=None
 ):
     """Return `ParallelCorpusIterator` for all corpora defined in opts."""
     corpora_iters = dict()

--- a/eole/inputters/text_corpus.py
+++ b/eole/inputters/text_corpus.py
@@ -367,6 +367,7 @@ class ImageTextCorpusIterator(object):
         offset=0,
         is_train=False,
         image_patch_size=16,
+        adapter="llava"
     ):
         self.cid = corpus.id
         self.corpus = corpus
@@ -378,12 +379,13 @@ class ImageTextCorpusIterator(object):
         self.offset = offset
         self.is_train = is_train
         self.image_patch_size = image_patch_size
+        self.adapter = adapter
 
     def _process(self, stream):
         for i, example in enumerate(stream):
             # process images
             processed_images = {
-                k: process_image(v, image_patch_size=self.image_patch_size)
+                k: process_image(v, adapter=self.adapter, image_patch_size=self.image_patch_size)
                 for k, v in example.get("images", {}).items()
             }
             text = example["text"]
@@ -410,7 +412,8 @@ class ImageTextCorpusIterator(object):
 
 
 def build_corpora_iters(
-    corpora, transforms, corpora_info, skip_empty_level="warning", stride=1, offset=0, image_patch_size=16
+    corpora, transforms, corpora_info, skip_empty_level="warning",
+    stride=1, offset=0, image_patch_size=16, adapter=None
 ):
     """Return `ParallelCorpusIterator` for all corpora defined in opts."""
     corpora_iters = dict()
@@ -436,6 +439,7 @@ def build_corpora_iters(
                 offset=offset,
                 is_train=getattr(corpus, "is_train", None),
                 image_patch_size=image_patch_size,
+                adapter=adapter,
             )
         corpora_iters[c_id] = corpus_iter
     return corpora_iters

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -26,7 +26,7 @@ from eole.models.model_saver import load_checkpoint
 from eole.modules.estimator import FeedForward
 
 from eole.encoders.vision import str2adapter
-from eole.encoders.vision import VisionLanguageAdapter, VisionEncoder
+from eole.encoders.vision import VisionEncoder
 
 
 def build_encoder(model_config, running_config=None):

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -86,10 +86,6 @@ def build_src_emb(model_config, vocabs, running_config=None):
 def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=False, src_emb=None):
     # Build embeddings.
     pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
-    if model_config.hidden_size == -1:
-        embed_scale = 1
-    else:
-        embed_scale = model_config.hidden_size**0.5
     tgt_emb = Embeddings(
         word_vec_size=model_config.embeddings.tgt_word_vec_size,
         position_encoding_type=model_config.embeddings.position_encoding_type,
@@ -97,12 +93,10 @@ def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=Fa
         dropout=getattr(running_config, "dropout", [0.0])[0],
         word_padding_idx=vocabs["tgt"][pad_token],
         word_vocab_size=len(vocabs["tgt"]),
-        # word_vocab_size=262208,  # hardcoded for gemma3 test
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_dec,
         n_positions=model_config.embeddings.n_positions,
         normalize=model_config.embeddings.normalize,
-        embed_scale=embed_scale,
     )
 
     if share_embeddings:

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -44,7 +44,6 @@ def build_adapter(model_config, running_config=None):
     Various adapter dispatcher function.
     """
     adapter_type = model_config.adapter
-    # print("ADAPTER_TYPE:", adapter_type)
     return str2adapter[adapter_type].from_config(model_config, running_config=running_config)
 
 
@@ -87,19 +86,23 @@ def build_src_emb(model_config, vocabs, running_config=None):
 def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=False, src_emb=None):
     # Build embeddings.
     pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
+    if model_config.hidden_size == -1:
+        embed_scale = 1
+    else:
+        embed_scale = model_config.hidden_size**0.5
     tgt_emb = Embeddings(
         word_vec_size=model_config.embeddings.tgt_word_vec_size,
         position_encoding_type=model_config.embeddings.position_encoding_type,
         position_shift=model_config.embeddings.position_shift,
         dropout=getattr(running_config, "dropout", [0.0])[0],
         word_padding_idx=vocabs["tgt"][pad_token],
-        # word_vocab_size=len(vocabs["tgt"]),
-        word_vocab_size=262208,  # hardcoded for gemma3 test
+        word_vocab_size=len(vocabs["tgt"]),
+        # word_vocab_size=262208,  # hardcoded for gemma3 test
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_dec,
         n_positions=model_config.embeddings.n_positions,
         normalize=model_config.embeddings.normalize,
-        embed_scale=model_config.hidden_size**0.5,  # hardcoded for gemma3, to add in config
+        embed_scale=embed_scale,
     )
 
     if share_embeddings:

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -47,6 +47,7 @@ def build_adapter(model_config, running_config=None):
     # print("ADAPTER_TYPE:", adapter_type)
     return str2adapter[adapter_type].from_config(model_config, running_config=running_config)
 
+
 def build_decoder(model_config, running_config=None, with_cross_attn=False):
     """
     Various decoder dispatcher function.
@@ -93,12 +94,12 @@ def build_tgt_emb(model_config, vocabs, running_config=None, share_embeddings=Fa
         dropout=getattr(running_config, "dropout", [0.0])[0],
         word_padding_idx=vocabs["tgt"][pad_token],
         # word_vocab_size=len(vocabs["tgt"]),
-        word_vocab_size=262208, # hardcoded for gemma3 test
+        word_vocab_size=262208,  # hardcoded for gemma3 test
         sparse=getattr(running_config, "optim", None) == "sparseadam",
         freeze_word_vecs=model_config.embeddings.freeze_word_vecs_dec,
         n_positions=model_config.embeddings.n_positions,
         normalize=model_config.embeddings.normalize,
-        embed_scale=model_config.hidden_size ** 0.5, # hardcoded for gemma3, to add in config
+        embed_scale=model_config.hidden_size**0.5,  # hardcoded for gemma3, to add in config
     )
 
     if share_embeddings:

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -94,7 +94,6 @@ class Embeddings(nn.Module):
         freeze_word_vecs=False,
         n_positions=1024,
         normalize=False,
-        embed_scale=1.0,
     ):
         super(Embeddings, self).__init__()
         self._validate_args()
@@ -117,7 +116,6 @@ class Embeddings(nn.Module):
         self.position_encoding_type = position_encoding_type
         self.position_shift = position_shift
         self.normalize = normalize
-        self.embed_scale = embed_scale
 
         if self.position_encoding_type == PositionEncodingType.Learned:
             self.pe = nn.Embedding(n_positions, word_vec_size)

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -193,8 +193,6 @@ class Embeddings(nn.Module):
             normalizer = torch.tensor(self.word_vec_size**0.5, dtype=emb.dtype)
             emb = emb * normalizer
 
-        emb = emb * self.embed_scale
-
         if self.dropout_p > 0:
             return self.dropout(emb)
         else:

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -117,6 +117,7 @@ class Embeddings(nn.Module):
         self.position_encoding_type = position_encoding_type
         self.position_shift = position_shift
         self.normalize = normalize
+        self.embed_scale = embed_scale
 
         if self.position_encoding_type == PositionEncodingType.Learned:
             self.pe = nn.Embedding(n_positions, word_vec_size)
@@ -132,8 +133,6 @@ class Embeddings(nn.Module):
 
         if freeze_word_vecs:
             self.embeddings.weight.requires_grad = False
-
-        self.embed_scale = embed_scale
 
     def _validate_args(
         self,

--- a/eole/modules/rmsnorm.py
+++ b/eole/modules/rmsnorm.py
@@ -24,7 +24,7 @@ class RMSNorm(torch.nn.Module):
         self.eps = eps
         self.weight = nn.Parameter(torch.ones(hidden_size))
 
-    @torch.compile(dynamic=True)
+    # @torch.compile(dynamic=True)
     def compute_rms(self, hidden_states, dtype, residual=False):
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)

--- a/eole/modules/rope.py
+++ b/eole/modules/rope.py
@@ -227,7 +227,7 @@ class RotaryPosition(nn.Module):
         if positions is None:
             tmax = torch.arange(maxseqlen, device=self.inv_freq.device)
         else:
-            tmax = positions
+            tmax = positions.to(self.inv_freq.device)
         rope = self.inv_freq[tmax].to(device)
         # rope is now matrix [maxseqlen, dim/2]
         # if device is not None:

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -646,7 +646,7 @@ class Inference(object):
             src_pad_mask=src_pad_mask,
             tgt_pad_mask=tgt_pad_mask,
             left_pad=left_pad,
-            # decoder_in=decoder_in,
+            decoder_in=decoder_in,
             image_token_id=self.image_token_id,
         )
         # Generator forward.

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -88,6 +88,7 @@ class Inference(object):
         add_estimator=False,
         optional_eos=[],
         id_tokenization=False,
+        image_token_id=10,
     ):
         self.model = model
         self.vocabs = vocabs
@@ -162,6 +163,7 @@ class Inference(object):
         self.return_gold_log_probs = return_gold_log_probs
         self.add_estimator = add_estimator
         self.id_tokenization = id_tokenization
+        self.image_token_id = image_token_id
 
     @classmethod
     def from_config(
@@ -194,6 +196,10 @@ class Inference(object):
         # TODO: maybe add dynamic part
 
         id_tokenization = False
+        if hasattr(model_config, "encoder") and model_config.encoder is not None:
+            image_token_id = getattr(model_config.encoder, "image_token_id", 10)
+        else:
+            image_token_id = 10
         if len(config.transforms) > 0:
             tail_transform_cls = AVAILABLE_TRANSFORMS.get(config.transforms[-1], None)
             if getattr(tail_transform_cls, "output_type", None) == "ids":
@@ -233,6 +239,7 @@ class Inference(object):
             add_estimator=model_config.add_estimator,
             optional_eos=config.optional_eos,
             id_tokenization=id_tokenization,
+            image_token_id=image_token_id,
         )
 
     def _log(self, msg):
@@ -640,6 +647,7 @@ class Inference(object):
             tgt_pad_mask=tgt_pad_mask,
             left_pad=left_pad,
             decoder_in=decoder_in,
+            image_token_id=self.image_token_id,
         )
         # Generator forward.
         if "std" in dec_attn:

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -646,7 +646,7 @@ class Inference(object):
             src_pad_mask=src_pad_mask,
             tgt_pad_mask=tgt_pad_mask,
             left_pad=left_pad,
-            decoder_in=decoder_in,
+            # decoder_in=decoder_in,
             image_token_id=self.image_token_id,
         )
         # Generator forward.

--- a/recipes/gemma3/test_inference.py
+++ b/recipes/gemma3/test_inference.py
@@ -6,8 +6,8 @@ from eole.inference_engine import InferenceEnginePY
 
 config = PredictConfig(
     model_path="/mnt/InternalCrucial4/LLM_work/gemma3-27b-it",
-    #model_path="/mnt/InternalCrucial4/LLM_work/mistralai/mistral-3.1-24B-instruct",
-    #model_path="/mnt/InternalCrucial4/LLM_work/mistralai/pixtral-12b",
+    # model_path="/mnt/InternalCrucial4/LLM_work/mistralai/mistral-3.1-24B-instruct",
+    # model_path="/mnt/InternalCrucial4/LLM_work/mistralai/pixtral-12b",
     src="dummy",
     # max_length=500,
     max_length=128,
@@ -49,7 +49,7 @@ test_input = [
         # }
         # {
         "text": "List the top 5 countries in Europe with the highest GDP\n{image1}",
-        #"text": "<s>[INST]List the top 5 countries in Europe with the highest GDP\n{image1}[/INST]",
+        # "text": "<s>[INST]List the top 5 countries in Europe with the highest GDP\n{image1}[/INST]",
         "images": {"image1": "gdp.png"},
     },
     # {

--- a/recipes/gemma3/test_inference.py
+++ b/recipes/gemma3/test_inference.py
@@ -6,6 +6,8 @@ from eole.inference_engine import InferenceEnginePY
 
 config = PredictConfig(
     model_path="/mnt/InternalCrucial4/LLM_work/gemma3-27b-it",
+    #model_path="/mnt/InternalCrucial4/LLM_work/mistralai/mistral-3.1-24B-instruct",
+    #model_path="/mnt/InternalCrucial4/LLM_work/mistralai/pixtral-12b",
     src="dummy",
     # max_length=500,
     max_length=128,
@@ -24,9 +26,9 @@ config = PredictConfig(
         "w_out",
     ],
     compute_dtype="bf16",
-    # top_p=0.8,
-    # temperature=0.35,
-    # beam_size=1,
+    top_p=0.8,
+    temperature=0.35,
+    beam_size=1,
     seed=42,
     batch_size=1,
     batch_type="sents",
@@ -47,6 +49,7 @@ test_input = [
         # }
         # {
         "text": "List the top 5 countries in Europe with the highest GDP\n{image1}",
+        #"text": "<s>[INST]List the top 5 countries in Europe with the highest GDP\n{image1}[/INST]",
         "images": {"image1": "gdp.png"},
     },
     # {

--- a/recipes/gemma3/test_inference.py
+++ b/recipes/gemma3/test_inference.py
@@ -5,24 +5,24 @@ from eole.config.run import *
 from eole.inference_engine import InferenceEnginePY
 
 config = PredictConfig(
-    model_path="./gemma-3-4b-pt",
+    model_path="/mnt/InternalCrucial4/LLM_work/gemma3-27b-it",
     src="dummy",
     # max_length=500,
-    max_length=20,
+    max_length=128,
     gpu_ranks=[0],
-    # quant_type="bnb_NF4",
+    quant_type="bnb_NF4",
     # quant_type="bnb_FP4",  # HF default, using it for initial reproducibility checks
-    # quant_layers=[
-    #     "gate_up_proj",
-    #     "down_proj",
-    #     "up_proj",
-    #     "linear_values",
-    #     "linear_query",
-    #     "linear_keys",
-    #     "final_linear",
-    #     "w_in",
-    #     "w_out",
-    # ],
+    quant_layers=[
+        "gate_up_proj",
+        "down_proj",
+        "up_proj",
+        "linear_values",
+        "linear_query",
+        "linear_keys",
+        "final_linear",
+        "w_in",
+        "w_out",
+    ],
     compute_dtype="bf16",
     # top_p=0.8,
     # temperature=0.35,
@@ -42,13 +42,13 @@ engine.predictor.model.count_parameters()
 
 test_input = [
     {
-        "text": "{image1} in this image, there is",
-        "images": {"image1": "./bee.jpg"},
-    }
-    # {
-    #     "text": "<s>[INST]List the top 5 countries in Europe with the highest GDP\n{image1}[/INST]",
-    #     "images": {"image1": "./test_data/gdp.png"},
-    # },
+        #    "text": "{image1} in this image, there is",
+        #    "images": {"image1": "./bee.jpg"},
+        # }
+        # {
+        "text": "List the top 5 countries in Europe with the highest GDP\n{image1}",
+        "images": {"image1": "gdp.png"},
+    },
     # {
     #     "text": "[INST]When did things start to go wrong for dark dragon?\n{image1}[/INST]",
     #     "images": {


### PR DESCRIPTION
Pushing a cleaner PR with changes from Main only.

It works fine for both Llava-type (pixtral/Mistral-24b) and Gemma3.

However still pending but maybe for later PR:

- clean the image_utils.py tools
- revamp the vision.py VisionEncoder to handle batches properly.

Open questions:
It seems that image masking (required for Gemma3?) is still ok for Llava (sounds reasonable). Hence I left the "decoder_in" arg in self.model.decoder() call from inference.py

I removed the patch from previous PR "mask = None" in VisionEncoder / vision.py (not sure why this was there)
