### PR TITLE
Better timing log and performance boost with fused layers

### DIFF
--- a/eole/bin/run/predict.py
+++ b/eole/bin/run/predict.py
@@ -8,7 +8,6 @@ from torch.profiler import profile, record_function, ProfilerActivity
 from eole.config.run import PredictConfig
 from eole.bin import register_bin
 from eole.bin.run import RunBin
-from time import time
 
 
 def model_type(config) -> ModelType:
@@ -51,9 +50,7 @@ class Predict(RunBin):
                     predict(config)
             print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=40))
         else:
-            init_time = time()
             predict(config)
-            print("Time w/o python interpreter load/terminate: ", time() - init_time)
 
 
 def _get_parser():

--- a/eole/config/inference.py
+++ b/eole/config/inference.py
@@ -94,6 +94,10 @@ class InferenceConfig(RunningConfig, DecodingConfig, LoRaConfig, QuantizeConfig)
         "Useful to test the performance of learnt alignments.",
     )
     report_time: bool = Field(default=False, description="Report some translation time metrics.")
+    fuse_kvq: bool = Field(default=False, description="Fuse K, V, Q Linear layers into a single KVQ in Self Attn.")
+    fuse_gate: bool = Field(
+        default=False, description="Fuse gate_up_proj and up_proj Linear layers into a single Linear."
+    )
     profile: bool = Field(default=False, description="Report pytorch profiling stats.")
     batch_size: int = Field(default=30, description="Batch size.")
     batch_type: Literal["sents", "tokens"] = Field(default="sents", description="Batch grouping for batch size.")

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -703,11 +703,11 @@ class TransformerModelConfig(TransformerConfig, BaseModelConfig):
         if not (isinstance(data, dict)):
             return data
         if "encoder" in data.keys():
-            data["encoder"].encoder_type = "transformer"
+            data["encoder"]["encoder_type"] = "transformer"
         else:
             data["encoder"] = {"encoder_type": "transformer"}
         if "decoder" in data.keys():
-            data["decoder"].decoder_type = "transformer"
+            data["decoder"]["decoder_type"] = "transformer"
         else:
             data["decoder"] = {"decoder_type": "transformer"}
         return data

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -66,13 +66,11 @@ class TransformerEncoderLayer(nn.Module):
         )
         if self.dropout_p > 0:
             context = self.dropout(context)
-        residual = layer_in + context
-        ff_in = self.post_attention_layernorm(residual) if not self.parallel_residual else norm_layer_in
-        # apply post attention norm and add residual after mlp
-        mlp = self.mlp(ff_in)
-        layer_out = layer_in + context + mlp
 
-        return layer_out
+        context.add_(layer_in)
+        ff_in = self.post_attention_layernorm(context) if not self.parallel_residual else norm_layer_in
+        # apply post attention norm and add residual after mlp
+        return context + self.mlp(ff_in)
 
     def update_dropout(self, dropout, attention_dropout):
         self.self_attn.update_dropout(attention_dropout)

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -229,10 +229,10 @@ class VisionLanguageAdapter(nn.Module):
 
 class Gemma3MultiModalProjector(nn.Module):
     # https://github.com/huggingface/transformers/blob/071a161d3e38f56dbda2743b979f0afeed2cd4f1/src/transformers/models/gemma3/modular_gemma3.py#L717
-    def __init__(self, in_dim, out_dim, image_size, patch_size, mm_tokens_per_image, lntype):
+    def __init__(self, in_dim, out_dim, image_size, patch_size, mm_tokens_per_image):
         super(Gemma3MultiModalProjector, self).__init__()
         self.w_in = nn.Linear(in_dim, out_dim, bias=False)
-        self.norm = LayerNorm[lntype](in_dim)
+        self.norm = LayerNorm["gemma-rms"](in_dim) # forced because no value in config file
         self.patches_per_image = int(image_size / patch_size)
         self.tokens_per_side = int(mm_tokens_per_image**0.5)
         self.kernel_size = self.patches_per_image // self.tokens_per_side
@@ -258,7 +258,6 @@ class Gemma3MultiModalProjector(nn.Module):
             image_size=model_config.encoder.image_size,
             patch_size=model_config.encoder.patch_size,
             mm_tokens_per_image=model_config.encoder.mm_tokens_per_image,
-            lntype=model_config.encoder.layer_norm,
         )
 
 

--- a/eole/encoders/vision.py
+++ b/eole/encoders/vision.py
@@ -232,7 +232,7 @@ class Gemma3MultiModalProjector(nn.Module):
     def __init__(self, in_dim, out_dim, image_size, patch_size, mm_tokens_per_image):
         super(Gemma3MultiModalProjector, self).__init__()
         self.w_in = nn.Linear(in_dim, out_dim, bias=False)
-        self.norm = LayerNorm["gemma-rms"](in_dim) # forced because no value in config file
+        self.norm = LayerNorm["gemma-rms"](in_dim)  # forced because no value in config file
         self.patches_per_image = int(image_size / patch_size)
         self.tokens_per_side = int(mm_tokens_per_image**0.5)
         self.kernel_size = self.patches_per_image // self.tokens_per_side

--- a/eole/inference_engine.py
+++ b/eole/inference_engine.py
@@ -2,6 +2,7 @@ import torch
 import json
 import os
 import codecs
+from time import time
 from eole.constants import CorpusTask, DefaultTokens, ModelType
 from eole.inputters.dynamic_iterator import build_dynamic_dataset_iter
 from eole.utils.distributed import ErrorHandler
@@ -145,6 +146,7 @@ class InferenceEnginePY(InferenceEngine):
 
         super().__init__(config)
         self.logger = init_logger(config.log_file)
+        t0 = time()
 
         if config.world_size > 1:
             mp = torch.multiprocessing.get_context("spawn")
@@ -186,6 +188,7 @@ class InferenceEnginePY(InferenceEngine):
             self.vocabs = self.predictor.vocabs
             self.transforms = make_transforms(config, self.transforms_cls, self.vocabs)
             self.transform_pipe = TransformPipe.build_from(self.transforms.values())
+        self.logger.info("Build and loading model took %.2f sec." % (time() - t0))
 
     @torch.inference_mode()
     def _predict(self, infer_iter, settings={}):

--- a/eole/inputters/text_corpus.py
+++ b/eole/inputters/text_corpus.py
@@ -5,11 +5,10 @@ from eole.utils.logging import logger
 from eole.constants import CorpusName, CorpusTask
 from eole.transforms import TransformPipe
 from eole.inputters.text_utils import transform_bucket
-from eole.inputters.image_utils import process_image
+
 from contextlib import contextmanager
 import itertools
 import json
-from datasets import load_dataset
 
 
 @contextmanager
@@ -154,6 +153,8 @@ class ParallelCorpus(object):
         Match the last '/field' to get the language / score field
         Potentially a config_name field between dataset_name and last field
         """
+        from datasets import load_dataset
+
         parts = hf_string.replace("hf://", "").split("/")
         dataset_name = "/".join(parts[:2])
         remaining_parts = parts[2:]
@@ -374,6 +375,8 @@ class ImageTextCorpusIterator(object):
         self.adapter = adapter
 
     def _process(self, stream):
+        from eole.inputters.image_utils import process_image
+
         for i, example in enumerate(stream):
             # process images
             processed_images = {

--- a/eole/modules/transformer_mlp.py
+++ b/eole/modules/transformer_mlp.py
@@ -1,5 +1,6 @@
 """MLP network from "Attention is All You Need"."""
 
+import torch
 import torch.nn as nn
 from torch.utils.checkpoint import checkpoint
 from torch.nn.utils import skip_init
@@ -25,6 +26,7 @@ class MLP(nn.Module):
         assert (
             model_config.transformer_ff % self.parallel_gpu == 0
         ), "Model intermediate ffn size must be divisible by the number of partitions"
+        self.model_config = model_config
         self.gate_up_proj = skip_init(
             nn.Linear,
             in_features=model_config.hidden_size,
@@ -42,20 +44,81 @@ class MLP(nn.Module):
         self.dropout_1 = nn.Dropout(self.dropout_p)
         self.dropout_2 = nn.Dropout(self.dropout_p)
         self.activation = ACTIVATION_FUNCTIONS[model_config.mlp_activation_fn]
-        self.up_proj = (
-            skip_init(
+        if model_config.mlp_activation_fn in ["gated-silu", "gated-gelu", "gated-gelu-tanh"]:
+            self.up_proj = skip_init(
                 nn.Linear,
                 in_features=model_config.hidden_size,
                 out_features=model_config.transformer_ff // self.parallel_gpu,
                 bias=model_config.add_ffnbias,
             )
-            if model_config.mlp_activation_fn in ["gated-silu", "gated-gelu", "gated-gelu-tanh"]
-            else None
-        )
+            self.forward = self.gated_forward
+        else:
+            self.up_proj = None
+            self.forward = self.simple_forward
 
         self.maybe_ckpt = checkpoint if "ffn" in getattr(running_config, "use_ckpting", []) else lambda f, x: f(x)
 
-    def forward(self, x):
+    def _fuse_gate(self) -> None:
+        if hasattr(self.gate_up_proj, "weight"):
+            new_gate = skip_init(
+                nn.Linear,
+                in_features=self.model_config.hidden_size,
+                out_features=self.model_config.transformer_ff // self.parallel_gpu * 2,
+                bias=self.model_config.add_ffnbias,
+            )
+            new_gate.weight = nn.Parameter(torch.cat([self.gate_up_proj.weight, self.up_proj.weight]))
+            if self.model_config.add_ffnbias:
+                new_gate.bias = nn.Parameter(torch.cat([self.gate_up_proj.bias, self.up_proj.bias]))
+
+        elif hasattr(self.gate_up_proj, "qweight") and hasattr(self.up_proj, "qweight"):
+            w_bit = self.gate_up_proj.w_bit
+            group_size = self.gate_up_proj.group_size
+
+            awq_cls = self.gate_up_proj.__class__
+            dim = 1 if awq_cls.__name__ == "WQLinear_GEMM" else 0
+            new_gate = awq_cls(
+                w_bit=w_bit,
+                group_size=group_size,
+                in_features=self.model_config.hidden_size,
+                out_features=self.model_config.transformer_ff // self.parallel_gpu * 2,
+                bias=self.model_config.add_ffnbias,
+                dev=self.gate_up_proj.qweight.device,
+            )
+            new_gate.qweight = torch.cat([self.gate_up_proj.qweight, self.up_proj.qweight], dim)
+            new_gate.qzeros = torch.cat([self.gate_up_proj.qzeros, self.up_proj.qzeros], dim)
+            new_gate.scales = torch.cat([self.gate_up_proj.scales, self.up_proj.scales], dim)
+        del self.up_proj
+        self.gate_up_proj = new_gate
+        self.forward = self.simple_forward
+        self.activation = ACTIVATION_FUNCTIONS["fused-" + self.model_config.mlp_activation_fn]
+
+    def gated_forward(self, x):
+        """Layer definition. Legacy Gated operations. No fusion.
+
+        Args:
+            x: ``(batch_size, input_len, model_dim)``
+
+        Returns:
+            (FloatTensor): Output ``(batch_size, input_len, model_dim)``.
+        """
+        mlp_out = self.maybe_ckpt(self.gate_up_proj, x)
+        mlp_out = self.activation(mlp_out)
+        mlp_out.mul_(self.maybe_ckpt(self.up_proj, x))
+        if self.dropout_p > 0:
+            mlp_out = self.dropout_1(mlp_out)
+        mlp_out = self.maybe_ckpt(self.down_proj, mlp_out)
+        if self.dropout_p > 0:
+            mlp_out = self.dropout_2(mlp_out)
+
+        if self.parallel_gpu > 1:
+            # all_reduce is an inplace op - not easily backprop
+            mlp_out1 = mlp_out.detach().clone()
+            all_reduce(mlp_out1)
+            mlp_out.copy_(mlp_out1 + (mlp_out - mlp_out.detach()))
+
+        return mlp_out
+
+    def simple_forward(self, x):
         """Layer definition.
 
         Args:
@@ -66,11 +129,10 @@ class MLP(nn.Module):
         """
         mlp_out = self.maybe_ckpt(self.gate_up_proj, x)
         mlp_out = self.activation(mlp_out)
-        if self.up_proj is not None:
-            mlp_out.mul_(self.maybe_ckpt(self.up_proj, x))
         if self.dropout_p > 0:
             mlp_out = self.dropout_1(mlp_out)
         mlp_out = self.maybe_ckpt(self.down_proj, mlp_out)
+
         if self.dropout_p > 0:
             mlp_out = self.dropout_2(mlp_out)
 

--- a/eole/predict/generator.py
+++ b/eole/predict/generator.py
@@ -5,8 +5,7 @@ from eole.constants import ModelType
 from eole.predict.greedy_search import GreedySearchLM
 from eole.predict.beam_search import BeamSearchLM
 from eole.utils.misc import tile
-
-# from time import time
+from time import time
 
 
 class GeneratorLM(Inference):
@@ -127,7 +126,8 @@ class GeneratorLM(Inference):
         )
 
         # (4) Begin decoding step by step:
-        # beg_time = time()
+        if self.report_time:
+            beg_time = time()
         for step in range(decode_strategy.max_length):
             decoder_input = src if step == 0 else decode_strategy.current_predictions.view(-1, 1)
             log_probs, attn = self._decode_and_generate(
@@ -154,8 +154,8 @@ class GeneratorLM(Inference):
                 # select indexes in model state/cache
                 self.model.decoder.map_state(lambda state: state[select_indices])
 
-            # if step == 0:
-            #     print("step0 time: ", time() - beg_time)
+            if step == 0 and self.report_time:
+                self.step0_time += time() - beg_time
 
         if self.add_estimator:
             # Prepare estimator input = decoder out of each pred with initial enc_out

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -639,7 +639,7 @@ class Inference(object):
             src_pad_mask = None
 
         if images is not None and step == 0:
-            emb = self.model.embed_vision_language_features(decoder_in, images)
+            emb = self.model.embed_vision_language_features(decoder_in, images=images)
         else:
             emb = self.model.tgt_emb(decoder_in, step=step)
 

--- a/eole/predict/inference.py
+++ b/eole/predict/inference.py
@@ -324,7 +324,6 @@ class Inference(object):
         all_estim = []
         all_predictions = []
 
-        torch.cuda.synchronize()
         start_time = time()
         self.step0_time = []
 
@@ -525,7 +524,6 @@ class Inference(object):
             gold_score_total += bucket_gold_score
             gold_words_total += bucket_gold_words
 
-        torch.cuda.synchronize()
         end_time = time()
 
         if self.report_score:

--- a/eole/predict/translator.py
+++ b/eole/predict/translator.py
@@ -7,6 +7,7 @@ from eole.predict.greedy_search import GreedySearch
 from eole.utils.misc import tile
 from eole.utils.alignment import extract_alignment
 from eole.predict.inference import Inference
+from time import time
 
 
 class Translator(Inference):
@@ -159,6 +160,8 @@ class Translator(Inference):
         batch_size = len(batch["srclen"])
 
         # (1) Run the encoder on the src.
+        if self.report_time:
+            beg_time = time()
         src, enc_final_hs, enc_out, src_len = self._run_encoder(batch)
         self.model.decoder.init_state(src=src, enc_out=enc_out, enc_final_hs=enc_final_hs)
 
@@ -218,6 +221,8 @@ class Translator(Inference):
 
             if parallel_paths > 1 or any_finished:
                 self.model.decoder.map_state(lambda state: state[select_indices])
+            if step == 0 and self.report_time:
+                self.step0_time += time() - beg_time
 
         if self.add_estimator:
             dec_in = [item for sublist in decode_strategy.predictions for item in sublist]

--- a/eole/predict/translator.py
+++ b/eole/predict/translator.py
@@ -161,6 +161,7 @@ class Translator(Inference):
 
         # (1) Run the encoder on the src.
         if self.report_time:
+            torch.cuda.synchronize()
             beg_time = time()
         src, enc_final_hs, enc_out, src_len = self._run_encoder(batch)
         self.model.decoder.init_state(src=src, enc_out=enc_out, enc_final_hs=enc_final_hs)
@@ -221,8 +222,10 @@ class Translator(Inference):
 
             if parallel_paths > 1 or any_finished:
                 self.model.decoder.map_state(lambda state: state[select_indices])
-            if step == 0 and self.report_time:
-                self.step0_time += time() - beg_time
+
+            if self.report_time and step == 0:
+                torch.cuda.synchronize()
+                self.step0_time.append(time() - beg_time)
 
         if self.add_estimator:
             dec_in = [item for sublist in decode_strategy.predictions for item in sublist]

--- a/eole/tests/pull_request_check.sh
+++ b/eole/tests/pull_request_check.sh
@@ -218,7 +218,7 @@ ${PYTHON} eole/bin/main.py train \
             -tgt_vocab $TMP_OUT_DIR/eole.vocab.tgt \
             -src_vocab_size 1000 \
             -tgt_vocab_size 1000 \
-            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Rotary"}}' \
+            -model '{"architecture": "transformer", "layers": 4, "hidden_size": 16, "transformer_ff": 64, "heads": 2, "rope_config": {}, "embeddings": {"word_vec_size": 16, "position_encoding_type": "Rotary"}}' \
             -training '{"batch_size": 10, "num_workers": 0, "bucket_size": 1024, "train_steps": 10, "valid_steps": 5}' \
             -valid_metrics "BLEU" "TER" \
             -report_every 2 \


### PR DESCRIPTION
Two new Bool for inference (not tested at training):

fuse_qkv: when dealing with small models or awq quantized models, reducing the number of kernel launches vs pure GPU compute helps a lot. Hence fusing the 3 self_MHA linear layers into one for a single Linear reduces the number of kernel launch.

fuse_gate: when MLP activation is gated (most LLM use it, Gated Silu, etc ...) the same principle apply we can perform a single Linear gate_up_proj and up_proj and also perform the activation in the same kernel.


Additional optimizations make the code base very efficient. (see below)