### PR TITLE
fix vllm regression in dispatch forward

### DIFF
--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -146,16 +146,14 @@ class TransformerDecoderLayer(nn.Module):
                     attn_mask=~src_pad_mask,
                     return_attn=return_attn,
                 )
-                ctx_attn.add_(self_attn)
-            else:
-                ctx_attn = self_attn
+                self_attn = self_attn + ctx_attn
             if not self.shared_layer_norm:
                 ff_in = self.residual_layernorm(layer_in)
             else:
                 ff_in = norm_layer_in
         else:
             if self.context_attn:
-                norm_query = self.precontext_layernorm(self_attn + layer_in)
+                norm_query = self.precontext_layernorm(self_attn)
                 ctx_attn, attns = self.context_attn(
                     enc_out,
                     enc_out,
@@ -165,12 +163,11 @@ class TransformerDecoderLayer(nn.Module):
                 )
                 if self.dropout_p > 0:
                     ctx_attn = self.dropout(ctx_attn)
-                ctx_attn.add_(self_attn)
-            else:
-                ctx_attn = self_attn
-            ff_in = self.post_attention_layernorm(ctx_attn)
+                self_attn = self_attn + ctx_attn
+
+            ff_in = self.post_attention_layernorm(self_attn)
         # we apply residual with un-normed
-        return ctx_attn + self.mlp(ff_in), attns
+        return self_attn + self.mlp(ff_in), attns
 
     def get_attn_align(self, layer_in, **kwargs):
         """:cite:`garg2019jointly`."""

--- a/eole/modules/rmsnorm.py
+++ b/eole/modules/rmsnorm.py
@@ -46,7 +46,7 @@ class RMSNorm(torch.nn.Module):
         if self.training or not _vllm_available:
             return self.compute_rms(hidden_states)
         else:
-            return self._vllm_rmsnorm(hidden_states)
+            return self._vllm_rmsnorm.forward_cuda(hidden_states)
 
     def forward(self, hidden_states):
         return self._forward(hidden_states)
@@ -78,7 +78,7 @@ class GemmaRMSNorm(RMSNorm):
         if self.training or not _vllm_available:
             return self.compute_rms(hidden_states, factor=1.0)
         else:
-            return self._vllm_gemmarmsnorm(hidden_states)
+            return self._vllm_gemmarmsnorm.forward_cuda(hidden_states)
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"

--- a/recipes/deepseekocr/pdf_ocr_mmd.py
+++ b/recipes/deepseekocr/pdf_ocr_mmd.py
@@ -177,9 +177,8 @@ if __name__ == "__main__":
         batch_size=48,
         batch_type="sents",
         report_time=True,
-        fuse_kvq=False,
+        fuse_kvq=True,
         fuse_gate=True,
-        # block_ngram_repeat=5,
     )
 
     config.data_type = "image"

--- a/recipes/deepseekocr/test_inference.py
+++ b/recipes/deepseekocr/test_inference.py
@@ -9,6 +9,7 @@ mydir = os.getenv("EOLE_MODEL_DIR")
 config = PredictConfig(
     model_path=os.path.join(mydir, "DeepSeek-OCR"),
     src="dummy",
+    self_attn_backend="flash",
     max_length=8192,
     gpu_ranks=[0],
     compute_dtype="bf16",
@@ -20,9 +21,8 @@ config = PredictConfig(
     batch_size=4,
     batch_type="sents",
     report_time=True,
-    fuse_kvq=False,
+    fuse_kvq=True,
     fuse_gate=True,
-    # block_ngram_repeat=5,
 )
 # print(config)
 

--- a/recipes/gemma3/test_inference.py
+++ b/recipes/gemma3/test_inference.py
@@ -9,20 +9,14 @@ mydir = os.getenv("EOLE_MODEL_DIR")
 config = PredictConfig(
     model_path=os.path.join(mydir, "gemma3-27b-it"),
     src="dummy",
-    max_length=800,
+    self_attn_backend="flash",
+    max_length=2048,
     gpu_ranks=[0],
-    # quant_type="bnb_NF4",
     quant_type="bnb_NF4",  # HF default, using it for initial reproducibility checks
     quant_layers=[
         "gate_up_proj",
         "down_proj",
         "up_proj",
-        "linear_values",
-        "linear_query",
-        "linear_keys",
-        "final_linear",
-        "w_in",
-        "w_out",
     ],
     compute_dtype="bf16",
     top_p=0.8,
@@ -32,6 +26,7 @@ config = PredictConfig(
     batch_size=1,
     batch_type="sents",
     report_time=True,
+    fuse_kvq=True,
 )
 
 # print(config)

--- a/recipes/hunyuanocr/test_inference.py
+++ b/recipes/hunyuanocr/test_inference.py
@@ -13,7 +13,7 @@ config = PredictConfig(
     max_length=4096,
     gpu_ranks=[0],
     compute_dtype="bf16",
-    top_k=1,
+    top_k=1.0,
     top_p=0.0,
     temperature=1.0,
     beam_size=1,
@@ -21,6 +21,8 @@ config = PredictConfig(
     batch_size=4,
     batch_type="sents",
     report_time=True,
+    fuse_gate=True,
+    fuse_kvq=True,
 )
 
 # print(config)

--- a/recipes/pixtral/test_inference.py
+++ b/recipes/pixtral/test_inference.py
@@ -9,21 +9,9 @@ mydir = os.getenv("EOLE_MODEL_DIR")
 config = PredictConfig(
     model_path=os.path.join(mydir, "mistralai/pixtral-12b"),
     src="dummy",
-    max_length=500,
+    self_attn_backend="flash",
+    max_length=2048,
     gpu_ranks=[0],
-    # quant_type="bnb_NF4",
-    # quant_type="bnb_NF4",  # HF default, using it for initial reproducibility checks
-    quant_layers=[
-        "gate_up_proj",
-        "down_proj",
-        "up_proj",
-        "linear_values",
-        "linear_query",
-        "linear_keys",
-        "final_linear",
-        "w_in",
-        "w_out",
-    ],
     compute_dtype="bf16",
     top_p=0.8,
     temperature=0.35,
@@ -32,6 +20,8 @@ config = PredictConfig(
     batch_size=2,
     batch_type="sents",
     report_time=True,
+    fuse_kvq=True,
+    fuse_gate=True,
 )
 
 # print(config)


### PR DESCRIPTION
Tried the fused kernel "fused_add_rms"
it brings almost zero improvement. de facto could be used in one place only (post_attention_layernorm)

while testing realized vLLM changed come behavior between 0.11.2 and 0.12.0
as of 0.12 forward dispatch prefers torch.compile but the Cuda kernel for RMSNorm is WAY faster
so this PR forces forward_cuda()

Also discovered a bug in transformer decoder layer precontext_layernorm (in context_attn mode only) was adding twice the residual since last october.

ALSO: for the record I tried other kernels, Liger, xformers, triton ones, the cuda vLLM is the fastest.
