### PR TITLE
Make triton fused_moe import optional so MoE module loads on platforms without triton (e.g. macOS)

### DIFF
--- a/eole/modules/moe.py
+++ b/eole/modules/moe.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from eole.modules.transformer_mlp import MLP
 from torch.distributed import all_reduce
+
 try:
     from eole.triton.fused_moe import fused_experts_impl
 except ImportError:


### PR DESCRIPTION
Added conditional optional loading for triton so MoE module loads on platforms without triton (e.g. macOS)