### PR TITLE
Add autocast support for MPS

### DIFF
--- a/eole/decoders/transformer.py
+++ b/eole/decoders/transformer.py
@@ -631,8 +631,8 @@ class TransformerDecoder(DecoderBase):
         b, l, d = emb.size()
         device = emb.device
         dtype = emb.dtype
-        if torch.is_autocast_enabled():
-            dtype = torch.get_autocast_gpu_dtype()
+        if torch.is_autocast_enabled(device.type):
+            dtype = torch.get_autocast_dtype(device.type)
 
         self.flash = (
             _FLASH_ATTN_AVAILABLE

--- a/eole/modules/sparse_activations.py
+++ b/eole/modules/sparse_activations.py
@@ -9,6 +9,7 @@ import torch
 from torch.autograd import Function
 from torch.amp import custom_fwd, custom_bwd
 import torch.nn as nn
+from eole.utils.misc import get_device_type
 
 
 def _make_ix_like(input, dim=0):
@@ -43,7 +44,7 @@ def _threshold_and_support(input, dim=0):
 
 class SparsemaxFunction(Function):
     @staticmethod
-    @custom_fwd(device_type="cuda")
+    @custom_fwd(device_type=get_device_type())
     def forward(ctx, input, dim=0):
         """sparsemax: normalizing sparse transform (a la softmax)
 
@@ -63,7 +64,7 @@ class SparsemaxFunction(Function):
         return output
 
     @staticmethod
-    @custom_bwd(device_type="cuda")
+    @custom_bwd(device_type=get_device_type())
     def backward(ctx, grad_output):
         supp_size, output = ctx.saved_tensors
         dim = ctx.dim

--- a/eole/modules/sparse_losses.py
+++ b/eole/modules/sparse_losses.py
@@ -2,12 +2,13 @@ import torch
 import torch.nn as nn
 from torch.autograd import Function
 from torch.amp import custom_fwd, custom_bwd
+from eole.utils.misc import get_device_type
 from eole.modules.sparse_activations import _threshold_and_support
 
 
 class SparsemaxLossFunction(Function):
     @staticmethod
-    @custom_fwd(device_type="cuda")
+    @custom_fwd(device_type=get_device_type())
     def forward(ctx, input, target):
         """
         input (FloatTensor): ``(n, num_classes)``.
@@ -26,7 +27,7 @@ class SparsemaxLossFunction(Function):
         return torch.clamp(x / 2 - z_k + 0.5, min=0.0)
 
     @staticmethod
-    @custom_bwd(device_type="cuda")
+    @custom_bwd(device_type=get_device_type())
     def backward(ctx, grad_output):
         input, target, tau_z = ctx.saved_tensors
         sparsemax_out = torch.clamp(input - tau_z, min=0)

--- a/eole/utils/optimizers.py
+++ b/eole/utils/optimizers.py
@@ -351,10 +351,10 @@ class Optimizer:
             use_amp=use_amp,
         )
 
-        # Initialize GradScaler for AMP
+        # Initialize GradScaler for AMP using the model's device
         if use_amp:
-            # Modern API: torch.amp.GradScaler with device specification
-            optimizer._scaler = GradScaler("cuda")
+            device_type = next(model.parameters()).device.type
+            optimizer._scaler = GradScaler(device_type)
 
         if optim_state_dict:
             optimizer.load_state_dict(optim_state_dict)


### PR DESCRIPTION
This pull request updates the handling of device types for autocasting and custom forward/backward passes, making the code more flexible and compatible with different hardware (e.g., CUDA, CPU). The main changes involve replacing hardcoded device type strings with dynamic device type detection using a new utility function, and ensuring that autocast and AMP scaler initialization use the correct device.

Device type handling improvements:

* Replaced hardcoded `"cuda"` device type in `@custom_fwd` and `@custom_bwd` decorators with a call to `get_device_type()` in `eole/modules/sparse_activations.py` and `eole/modules/sparse_losses.py`, allowing dynamic selection of device type. [[1]](diffhunk://#diff-e28db03520f1d9528a34d84ee59151b0ad9aefbd2b75de740bb6cbb8e2eb6270L46-R47) [[2]](diffhunk://#diff-e28db03520f1d9528a34d84ee59151b0ad9aefbd2b75de740bb6cbb8e2eb6270L66-R67) [[3]](diffhunk://#diff-e790617ac09820c75128cf6183782a3367aaa969e87035674946d96548aa20ccR5-R11) [[4]](diffhunk://#diff-e790617ac09820c75128cf6183782a3367aaa969e87035674946d96548aa20ccL29-R30)
* Updated initialization of AMP `GradScaler` in `eole/utils/optimizers.py` to use the model's actual device type instead of hardcoding `"cuda"`.

Autocast dtype management:

* Updated `_init_cache` in `eole/decoders/transformer.py` to use `torch.is_autocast_enabled(device.type)` and `torch.get_autocast_dtype(device.type)` for more accurate autocast state and dtype selection based on the current device.