### PR TITLE
Refactor sparse gradient detection in SparseAdam optimizer

### DIFF
--- a/eole/utils/optimizers.py
+++ b/eole/utils/optimizers.py
@@ -94,19 +94,18 @@ def _build_sparse_adam_optimizer(
     """Build sparse Adam optimizer for embeddings."""
     dense_params = []
     sparse_params = []
-    sparse_param_names = set()
+    sparse_param_ids = set()
 
     for module_name, module in model.named_modules():
         if isinstance(module, torch.nn.Embedding) and getattr(module, "sparse", False):
-            for param_name, param in module.named_parameters():
-                if param.requires_grad:
-                    full_name = f"{module_name}.{param_name}" if module_name else param_name
-                    sparse_param_names.add(full_name)
+            weight_param = getattr(module, "weight", None)
+            if weight_param is not None and weight_param.requires_grad:
+                sparse_param_ids.add(id(weight_param))
 
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
-        if name in sparse_param_names:
+        if id(param) in sparse_param_ids:
             sparse_params.append(param)
         else:
             dense_params.append(param)


### PR DESCRIPTION
# TODO description : 

It's  related to sparse embeddings , the previous validation logic relies on string pattern matching ,  it only checks for substrings like embed.  

I've searched extensively but haven't found any documentation on sparse handling. However, I clearly see sparse settings on lines 93 and 100 of the `eole/modules/embeddings.py` file, which confuses me. I suspect the initial implementation might have overlooked this setting.

```python
        # TODO: Find a better way to check for sparse gradients
        if "embed" in name:
```

--- 
# My plan 
1. Storing sparse information takes approximately O(n) time.
2. Table lookup, the same as the original implementation, is O(n).

This mainly uses PyTorch functions; I'm not sure if there's a more elegant way to implement it.