### PR TITLE
Add trackio experiment tracking as an optional logging backend

### DIFF
--- a/docs/docusaurus_tsx/docs/concepts/experiment_reporting.md
+++ b/docs/docusaurus_tsx/docs/concepts/experiment_reporting.md
@@ -1,0 +1,128 @@
+---
+sidebar_position: 5
+description: How to configure stdout, TensorBoard, and Trackio reporting during training.
+---
+
+# Experiment Reporting
+
+EOLE supports multiple reporting backends during training:
+
+- stdout (always enabled)
+- TensorBoard (optional)
+- Trackio (optional)
+
+## Stdout Reporting
+
+Stdout reporting writes periodic training metrics directly to the process logs and is always enabled.
+
+Use `report_every` to control the step interval for these logs.
+
+```yaml
+report_every: 100
+```
+
+## TensorBoard Reporting
+
+[`TensorBoard`](https://www.tensorflow.org/tensorboard) is a local dashboard for visualizing scalar metrics over time.
+
+Enable TensorBoard in your train config with:
+
+```yaml
+tensorboard: true
+tensorboard_log_dir: runs/eole
+```
+
+When enabled, EOLE creates a dated run directory under `tensorboard_log_dir` and logs training/validation metrics.
+
+To visualize logs:
+
+```bash
+tensorboard --logdir runs/eole
+```
+
+## Trackio Reporting
+
+[`Trackio`](https://huggingface.co/docs/trackio/index) is an experiment tracking backend for local-first logging and optional remote dashboards.
+
+Trackio is an optional dependency:
+
+```bash
+pip install -e ".[trackio]"
+```
+
+Enable Trackio in your train config:
+
+```yaml
+trackio: true
+trackio_project: eole
+trackio_run_name: my-run-name  # optional
+trackio_space_id: username/space_id  # optional
+trackio_bucket_id: my-bucket-id  # optional
+```
+
+Notes:
+
+- `trackio_run_name`: optional run name (auto-generated if omitted)
+- `trackio_space_id`: optional Hugging Face Trackio Space target
+- `trackio_bucket_id`: optional Hugging Face bucket for persistence
+
+If available, EOLE also logs model and training configuration to Trackio's run config.
+
+At runtime, the following failure behavior happens:
+- If Trackio is not installed, EOLE logs a warning and continues training.
+- If Trackio initialization fails, EOLE logs a warning and continues training.
+- If Trackio raises during runtime logging, EOLE logs a warning once and disables Trackio for the rest of the run.
+
+## Distributed behavior
+
+In distributed training, TensorBoard and Trackio are initialized on rank 0 (`gpu_rank <= 0`) only, to avoid duplicate logging.
+
+## Config snippet example
+
+```yaml
+report_every: 100
+
+tensorboard: true
+tensorboard_log_dir: runs/eole
+
+trackio: true
+trackio_project: eole
+trackio_run_name: exp-001
+```
+
+## Extending with a Custom Report Backend
+
+For advanced integrations, implement your own manager by subclassing `ReportMgrBase` from `eole.utils.report_manager` and then compose it with `CompositeReportMgr`.
+
+At minimum, implement:
+
+- `_report_training(...)` for step-level periodic logging
+- `_report_step(...)` for end-of-step train/valid summaries
+- `close()` if your backend owns external resources
+
+If you instantiate a manager directly, call `start()` before the first `report_training(...)` call so `start_time` is initialized.
+
+Example sketch:
+
+```python
+from eole.utils.report_manager import CompositeReportMgr, ReportMgrBase, StdoutReportMgr
+
+
+class MyBackendReportMgr(ReportMgrBase):
+    def _report_training(self, step, num_steps, learning_rate, patience, report_stats):
+        # send training metrics to your backend
+        pass
+
+    def _report_step(self, lr, patience, step, valid_stats=None, train_stats=None):
+        # send step summary to your backend
+        pass
+
+
+report_mgr = CompositeReportMgr(
+    report_every=100,
+    managers=[
+        StdoutReportMgr(report_every=100),
+        MyBackendReportMgr(report_every=100),
+    ],
+)
+```

--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -123,6 +123,19 @@ class LoggingConfig(Config):
     tensorboard_log_dir_dated: str | None = (
         None  # field dynamically populated in build_report_manager, might improve later
     )
+    trackio: bool = Field(default=False, description="Use trackio for experiment tracking during training.")
+    trackio_project: str = Field(default="eole", description="Trackio project name.")
+    trackio_run_name: str | None = Field(
+        default=None, description="Trackio run name. Auto-generated if not set."
+    )
+    trackio_space_id: str | None = Field(
+        default=None,
+        description="HuggingFace Space ID for remote trackio dashboard (e.g. 'username/space_id').",
+    )
+    trackio_bucket_id: str | None = Field(
+        default=None,
+        description="HuggingFace Bucket ID for metric persistence.",
+    )
 
 
 class RunningConfig(DistributedConfig):

--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -125,9 +125,7 @@ class LoggingConfig(Config):
     )
     trackio: bool = Field(default=False, description="Use trackio for experiment tracking during training.")
     trackio_project: str = Field(default="eole", description="Trackio project name.")
-    trackio_run_name: str | None = Field(
-        default=None, description="Trackio run name. Auto-generated if not set."
-    )
+    trackio_run_name: str | None = Field(default=None, description="Trackio run name. Auto-generated if not set.")
     trackio_space_id: str | None = Field(
         default=None,
         description="HuggingFace Space ID for remote trackio dashboard (e.g. 'username/space_id').",

--- a/eole/tests/test_report_manager.py
+++ b/eole/tests/test_report_manager.py
@@ -37,12 +37,8 @@ class TestCompositeReportMgr(unittest.TestCase):
 
         composite._report_step(0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats)
 
-        mgr1._report_step.assert_called_once_with(
-            0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats
-        )
-        mgr2._report_step.assert_called_once_with(
-            0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats
-        )
+        mgr1._report_step.assert_called_once_with(0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats)
+        mgr2._report_step.assert_called_once_with(0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats)
 
     def test_close_continues_on_failure(self):
         mgr1 = self._make_mock_manager()

--- a/eole/tests/test_report_manager.py
+++ b/eole/tests/test_report_manager.py
@@ -1,0 +1,144 @@
+"""Tests for the report manager classes."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from eole.utils.report_manager import (
+    CompositeReportMgr,
+    ReportMgrBase,
+    StdoutReportMgr,
+    TrackioReportMgr,
+)
+
+
+class TestCompositeReportMgr(unittest.TestCase):
+    def _make_mock_manager(self):
+        mgr = MagicMock(spec=ReportMgrBase)
+        mgr.start_time = -1.0
+        return mgr
+
+    def test_dispatches_report_training_to_all_managers(self):
+        mgr1 = self._make_mock_manager()
+        mgr2 = self._make_mock_manager()
+        composite = CompositeReportMgr(report_every=5, managers=[mgr1, mgr2])
+        stats = MagicMock()
+
+        composite._report_training(10, 100, 0.001, None, stats)
+
+        mgr1._report_training.assert_called_once_with(10, 100, 0.001, None, stats)
+        mgr2._report_training.assert_called_once_with(10, 100, 0.001, None, stats)
+
+    def test_dispatches_report_step_to_all_managers(self):
+        mgr1 = self._make_mock_manager()
+        mgr2 = self._make_mock_manager()
+        composite = CompositeReportMgr(report_every=5, managers=[mgr1, mgr2])
+        train_stats = MagicMock()
+        valid_stats = MagicMock()
+
+        composite._report_step(0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats)
+
+        mgr1._report_step.assert_called_once_with(
+            0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats
+        )
+        mgr2._report_step.assert_called_once_with(
+            0.001, None, 10, valid_stats=valid_stats, train_stats=train_stats
+        )
+
+    def test_close_continues_on_failure(self):
+        mgr1 = self._make_mock_manager()
+        mgr2 = self._make_mock_manager()
+        mgr1.close.side_effect = RuntimeError("tensorboard exploded")
+        composite = CompositeReportMgr(report_every=5, managers=[mgr1, mgr2])
+
+        composite.close()
+
+        mgr1.close.assert_called_once()
+        mgr2.close.assert_called_once()
+
+    def test_start_time_propagates_to_children(self):
+        mgr1 = self._make_mock_manager()
+        mgr2 = self._make_mock_manager()
+        composite = CompositeReportMgr(report_every=5, managers=[mgr1, mgr2])
+
+        composite.start_time = 42.0
+
+        assert composite.start_time == 42.0
+        assert mgr1.start_time == 42.0
+        assert mgr2.start_time == 42.0
+
+    def test_start_sets_time_on_all(self):
+        mgr1 = self._make_mock_manager()
+        mgr2 = self._make_mock_manager()
+        composite = CompositeReportMgr(report_every=5, managers=[mgr1, mgr2])
+
+        composite.start()
+
+        assert composite.start_time > 0
+        assert mgr1.start_time == composite.start_time
+        assert mgr2.start_time == composite.start_time
+
+
+class TestStdoutReportMgr(unittest.TestCase):
+    def test_report_training_calls_output(self):
+        mgr = StdoutReportMgr(report_every=5)
+        mgr.start_time = 1.0
+        stats = MagicMock()
+
+        mgr._report_training(10, 100, 0.001, None, stats)
+
+        stats.output.assert_called_once_with(10, 100, 0.001, mgr.start_time)
+
+
+class TestTrackioReportMgr(unittest.TestCase):
+    def test_disables_on_log_failure(self):
+        mgr = TrackioReportMgr(report_every=5)
+        stats = MagicMock()
+        stats.log_trackio.side_effect = RuntimeError("network error")
+
+        mgr._report_training(10, 100, 0.001, None, stats)
+
+        assert mgr._disabled is True
+
+    def test_does_not_call_after_disabled(self):
+        mgr = TrackioReportMgr(report_every=5)
+        stats = MagicMock()
+        stats.log_trackio.side_effect = RuntimeError("network error")
+
+        # First call triggers disable
+        mgr._report_training(10, 100, 0.001, None, stats)
+        stats.log_trackio.reset_mock()
+
+        # Second call should not attempt logging
+        mgr._report_training(15, 100, 0.001, None, stats)
+        stats.log_trackio.assert_not_called()
+
+    def test_report_step_disables_on_failure(self):
+        mgr = TrackioReportMgr(report_every=5)
+        train_stats = MagicMock()
+        train_stats.log_trackio.side_effect = RuntimeError("network error")
+
+        mgr._report_step(0.001, None, 10, train_stats=train_stats)
+
+        assert mgr._disabled is True
+
+    @patch("eole.utils.report_manager.trackio", create=True)
+    def test_close_calls_finish(self, mock_trackio):
+        mgr = TrackioReportMgr(report_every=5)
+
+        with patch.dict("sys.modules", {"trackio": mock_trackio}):
+            mgr.close()
+
+        mock_trackio.finish.assert_called_once()
+
+    @patch("eole.utils.report_manager.trackio", create=True)
+    def test_close_skipped_when_disabled(self, mock_trackio):
+        mgr = TrackioReportMgr(report_every=5)
+        mgr._disabled = True
+
+        mgr.close()
+
+        mock_trackio.finish.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eole/train_single.py
+++ b/eole/train_single.py
@@ -241,17 +241,16 @@ def main(config: TrainConfig, device_id: int):
     train_steps = _calculate_train_steps(context.config.training.train_steps, context.config.training.single_pass)
 
     # Start training
-    trainer.train(
-        train_iter,
-        train_steps,
-        save_checkpoint_steps=context.config.training.save_checkpoint_steps,
-        valid_iter=valid_iter,
-        valid_steps=context.config.training.valid_steps,
-    )
-
-    # Cleanup
-    if trainer.report_manager.tensorboard_writer is not None:
-        trainer.report_manager.tensorboard_writer.close()
+    try:
+        trainer.train(
+            train_iter,
+            train_steps,
+            save_checkpoint_steps=context.config.training.save_checkpoint_steps,
+            valid_iter=valid_iter,
+            valid_steps=context.config.training.valid_steps,
+        )
+    finally:
+        trainer.report_manager.close()
 
 
 def _calculate_parallel_params(device_id: int, training_config: Any) -> Tuple[int, int]:

--- a/eole/utils/__init__.py
+++ b/eole/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from eole.utils.misc import use_gpu, set_random_seed
 from eole.utils.alignment import make_batch_align_matrix
-from eole.utils.report_manager import ReportMgr, build_report_manager
+from eole.utils.report_manager import build_report_manager
 from eole.utils.statistics import Statistics
 from eole.utils.optimizers import MultipleOptimizer, Optimizer
 from eole.utils.attention_entropy import (
@@ -16,7 +16,6 @@ from eole.utils.earlystopping import EarlyStopping, scorers_from_config
 __all__ = [
     "use_gpu",
     "set_random_seed",
-    "ReportMgr",
     "build_report_manager",
     "Statistics",
     "MultipleOptimizer",

--- a/eole/utils/report_manager.py
+++ b/eole/utils/report_manager.py
@@ -9,17 +9,46 @@ from eole.utils.logging import logger
 
 
 def build_report_manager(config, gpu_rank):
+    managers = []
+
+    # Stdout is always enabled
+    managers.append(StdoutReportMgr(config.report_every))
+
+    # TensorBoard
     if config.tensorboard and gpu_rank <= 0:
         from torch.utils.tensorboard import SummaryWriter
 
         if getattr(config, "tensorboard_log_dir_dated", None) is None:
             config.tensorboard_log_dir_dated = config.tensorboard_log_dir + datetime.now().strftime("/%b-%d_%H-%M-%S")
         writer = SummaryWriter(config.tensorboard_log_dir_dated, comment="Unmt")
-    else:
-        writer = None
+        managers.append(TensorboardReportMgr(config.report_every, writer))
 
-    report_mgr = ReportMgr(config.report_every, start_time=-1, tensorboard_writer=writer)
-    return report_mgr
+    # Trackio
+    if config.trackio and gpu_rank <= 0:
+        try:
+            import trackio
+
+            trackio.init(
+                project=config.trackio_project,
+                name=config.trackio_run_name,
+                space_id=config.trackio_space_id,
+                bucket_id=config.trackio_bucket_id,
+            )
+            # Log model and training config as hyperparameters
+            trackio_config = {}
+            if hasattr(config, "model") and config.model is not None:
+                trackio_config["model"] = config.model.model_dump()
+            if hasattr(config, "training") and config.training is not None:
+                trackio_config["training"] = config.training.model_dump()
+            if trackio_config:
+                trackio.config.update(trackio_config)
+            managers.append(TrackioReportMgr(config.report_every))
+        except ImportError:
+            logger.warning("trackio not installed; skipping trackio logging.")
+        except Exception:
+            logger.warning("Failed to initialize trackio; skipping trackio logging.", exc_info=True)
+
+    return CompositeReportMgr(config.report_every, managers)
 
 
 class ReportMgrBase(object):
@@ -48,7 +77,7 @@ class ReportMgrBase(object):
 
     def report_training(self, step, num_steps, learning_rate, patience, report_stats, multigpu=False):
         """
-        This is the user-defined batch-level traing progress
+        This is the user-defined batch-level training progress
         report function.
         Args:
             step(int): current step count.
@@ -92,39 +121,18 @@ class ReportMgrBase(object):
     def _report_step(self, *args, **kwargs):
         raise NotImplementedError()
 
+    def close(self):
+        """Clean up resources. Override in subclasses."""
+        pass
 
-class ReportMgr(ReportMgrBase):
-    def __init__(self, report_every, start_time=-1.0, tensorboard_writer=None):
-        """
-        A report manager that writes statistics on standard output as well as
-        (optionally) TensorBoard
 
-        Args:
-            report_every(int): Report status every this many sentences
-            tensorboard_writer(:obj:`tensorboard.SummaryWriter`):
-                The TensorBoard Summary writer to use or None
-        """
-        super(ReportMgr, self).__init__(report_every, start_time)
-        self.tensorboard_writer = tensorboard_writer
-
-    def maybe_log_tensorboard(self, stats, prefix, learning_rate, patience, step):
-        if self.tensorboard_writer is not None:
-            stats.log_tensorboard(prefix, self.tensorboard_writer, learning_rate, patience, step)
+class StdoutReportMgr(ReportMgrBase):
+    """Report manager that writes statistics to standard output."""
 
     def _report_training(self, step, num_steps, learning_rate, patience, report_stats):
-        """
-        See base class method `ReportMgrBase.report_training`.
-        """
         report_stats.output(step, num_steps, learning_rate, self.start_time)
-        self.maybe_log_tensorboard(report_stats, "progress", learning_rate, patience, step)
-        report_stats = eole.utils.Statistics()
-
-        return report_stats
 
     def _report_step(self, lr, patience, step, valid_stats=None, train_stats=None):
-        """
-        See base class method `ReportMgrBase.report_step`.
-        """
         if train_stats is not None:
             self.log("Train perplexity: %g" % train_stats.ppl())
             self.log("Train accuracy: %g" % train_stats.accuracy())
@@ -138,10 +146,109 @@ class ReportMgr(ReportMgrBase):
                     train_stats.n_sents / train_stats.n_batchs,
                 )
             )
-
-            self.maybe_log_tensorboard(train_stats, "train", lr, patience, step)
         if valid_stats is not None:
             self.log("Validation perplexity: %g" % valid_stats.ppl())
             self.log("Validation accuracy: %g" % valid_stats.accuracy())
 
-            self.maybe_log_tensorboard(valid_stats, "valid", lr, patience, step)
+
+class TensorboardReportMgr(ReportMgrBase):
+    """Report manager that logs statistics to TensorBoard."""
+
+    def __init__(self, report_every, writer, start_time=-1.0):
+        super().__init__(report_every, start_time)
+        self.writer = writer
+
+    def _report_training(self, step, num_steps, learning_rate, patience, report_stats):
+        report_stats.log_tensorboard("progress", self.writer, learning_rate, patience, step)
+
+    def _report_step(self, lr, patience, step, valid_stats=None, train_stats=None):
+        if train_stats is not None:
+            train_stats.log_tensorboard("train", self.writer, lr, patience, step)
+        if valid_stats is not None:
+            valid_stats.log_tensorboard("valid", self.writer, lr, patience, step)
+
+    def close(self):
+        self.writer.close()
+
+
+class TrackioReportMgr(ReportMgrBase):
+    """Report manager that logs statistics to trackio.
+
+    Fail-safe: if trackio raises at runtime (e.g. network error when logging
+    to a remote HF Space or self-hosted server), the error is logged once and
+    trackio is disabled for the rest of the run.
+    """
+
+    def __init__(self, report_every, start_time=-1.0):
+        super().__init__(report_every, start_time)
+        self._disabled = False
+
+    def _report_training(self, step, num_steps, learning_rate, patience, report_stats):
+        if self._disabled:
+            return
+        try:
+            report_stats.log_trackio("progress", learning_rate, patience, step)
+        except Exception:
+            logger.warning("trackio logging failed; disabling for the rest of this run.", exc_info=True)
+            self._disabled = True
+
+    def _report_step(self, lr, patience, step, valid_stats=None, train_stats=None):
+        if self._disabled:
+            return
+        try:
+            if train_stats is not None:
+                train_stats.log_trackio("train", lr, patience, step)
+            if valid_stats is not None:
+                valid_stats.log_trackio("valid", lr, patience, step)
+        except Exception:
+            logger.warning("trackio logging failed; disabling for the rest of this run.", exc_info=True)
+            self._disabled = True
+
+    def close(self):
+        if self._disabled:
+            return
+        try:
+            import trackio
+
+            trackio.finish()
+        except Exception:
+            logger.warning("trackio finish failed.", exc_info=True)
+
+
+class CompositeReportMgr(ReportMgrBase):
+    """Report manager that dispatches to multiple backend managers."""
+
+    def __init__(self, report_every, managers, start_time=-1.0):
+        self.managers = managers  # set before super() so the start_time setter can propagate
+        super().__init__(report_every, start_time)
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, value):
+        self._start_time = value
+        for mgr in self.managers:
+            mgr.start_time = value
+
+    def start(self):
+        self.start_time = time.time()
+
+    def _report_training(self, step, num_steps, learning_rate, patience, report_stats):
+        # Call _report_training directly on children rather than report_training,
+        # because the step-check and multigpu gather in the base class should
+        # only happen once (in this composite), not once per child.
+        for mgr in self.managers:
+            mgr._report_training(step, num_steps, learning_rate, patience, report_stats)
+
+    def _report_step(self, lr, patience, step, valid_stats=None, train_stats=None):
+        for mgr in self.managers:
+            mgr._report_step(lr, patience, step, valid_stats=valid_stats, train_stats=train_stats)
+
+    def close(self):
+        for mgr in self.managers:
+            try:
+                mgr.close()
+            except Exception:
+                logger.warning("Failed to close %s.", mgr.__class__.__name__, exc_info=True)

--- a/eole/utils/statistics.py
+++ b/eole/utils/statistics.py
@@ -198,3 +198,22 @@ class Statistics(object):
         writer.add_scalar(prefix + "/lr", learning_rate, step)
         if patience is not None:
             writer.add_scalar(prefix + "/patience", patience, step)
+
+    def log_trackio(self, prefix, learning_rate, patience, step):
+        """Log statistics to trackio."""
+        import trackio
+
+        t = self.elapsed_time()
+        metrics = {
+            f"{prefix}/xent": self.xent(),
+            f"{prefix}/ppl": self.ppl(),
+            f"{prefix}/attention_entropy": self.avg_attention_entropy(),
+            f"{prefix}/accuracy": self.accuracy(),
+            f"{prefix}/tgtper": self.n_tokens / t,
+            f"{prefix}/lr": learning_rate,
+        }
+        for k, v in self.computed_metrics.items():
+            metrics[f"{prefix}/{k}"] = round(v, 4)
+        if patience is not None:
+            metrics[f"{prefix}/patience"] = patience
+        trackio.log(metrics, step=step)

--- a/eole/utils/statistics.py
+++ b/eole/utils/statistics.py
@@ -209,7 +209,7 @@ class Statistics(object):
             f"{prefix}/ppl": self.ppl(),
             f"{prefix}/attention_entropy": self.avg_attention_entropy(),
             f"{prefix}/accuracy": self.accuracy(),
-            f"{prefix}/tgtper": self.n_tokens / t,
+            f"{prefix}/tgtper": self.n_tokens / (t + 1e-5),
             f"{prefix}/lr": learning_rate,
         }
         for k, v in self.computed_metrics.items():

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,9 @@ setup(
         "waitress",
         "pydantic",
     ],
-    extras_require={"wer": ["jiwer>=3.0", "whisper-normalizer>=0.1"]},
+    extras_require={
+        "wer": ["jiwer>=3.0", "whisper-normalizer>=0.1"],
+        "trackio": ["trackio>=0.23.0"],
+    },
     entry_points={"console_scripts": ["eole=eole.bin.main:main"]},
 )


### PR DESCRIPTION
Refactors existing standard output and TensorBoard reporting into their own reporting managers instances, and introduces a new [Trackio](https://github.com/gradio-app/trackio) reporting manager. 

It adds configuration options for Trackio integration, refactors the report manager infrastructure to support multiple simultaneous backends (i.e. Composite Reporting Managers), and provides error handling for logging failures.

