### PR TITLE
Add native COMET/KIWI scoring with encoder scorer models

### DIFF
--- a/docs/docusaurus_tsx/docs/concepts/command_line.md
+++ b/docs/docusaurus_tsx/docs/concepts/command_line.md
@@ -16,7 +16,7 @@ description: Recap of command line utilities and how to call them.
 
 ### Model Conversion Tools
 - **`convert`** 
-  - Flavors: `HF` (universal Hugging Face converter), `T5`, `onmt_config` (legacy OpenNMT-py config migration)
+  - Flavors: `HF` (universal Hugging Face converter), `T5`, `COMET`, `onmt_config` (legacy OpenNMT-py config migration)
 
 ### Model Management Tools
 - **`model`**
@@ -47,3 +47,20 @@ All other tools have specific arguments that can be inspected via the command he
 ```sh
 eole tool_name -h
 ```
+
+## Native EOLE COMET Scoring
+
+EOLE supports native scoring with converted [Unbabel COMET](https://github.com/Unbabel/COMET)
+metrics through `EOLE-COMET` and `EOLE-COMET-KIWI`. These models use EOLE's
+generic encoder-only `transformer_encoder_scorer` architecture with the
+COMET-specific `scoring_type: comet` specialization.
+
+```sh
+eole convert COMET --model Unbabel/wmt22-comet-da --output /path/to/converted/wmt22-comet-da
+eole convert COMET --model Unbabel/wmt22-cometkiwi-da --output /path/to/converted/wmt22-cometkiwi-da
+```
+
+Then use the converted model directory in your training config with:
+
+- `valid_metrics: ["EOLE-COMET"]` or `valid_metrics: ["EOLE-COMET-KIWI"]`
+- `comet_model: /path/to/converted/model`

--- a/docs/docusaurus_tsx/docs/concepts/command_line.md
+++ b/docs/docusaurus_tsx/docs/concepts/command_line.md
@@ -51,16 +51,21 @@ eole tool_name -h
 ## Native EOLE COMET Scoring
 
 EOLE supports native scoring with converted [Unbabel COMET](https://github.com/Unbabel/COMET)
-metrics through `EOLE-COMET` and `EOLE-COMET-KIWI`. These models use EOLE's
-generic encoder-only `transformer_encoder_scorer` architecture with the
-COMET-specific `scoring_type: comet` specialization.
+metrics through `EOLE-COMET`, `EOLE-COMET-KIWI`, and `EOLE-XCOMET`. These models
+use EOLE's generic encoder-only `transformer_encoder_scorer` architecture with
+the COMET-specific `scoring_type: comet` specialization.
 
 ```sh
 eole convert COMET --model Unbabel/wmt22-comet-da --output /path/to/converted/wmt22-comet-da
 eole convert COMET --model Unbabel/wmt22-cometkiwi-da --output /path/to/converted/wmt22-cometkiwi-da
+eole convert COMET --model Unbabel/XCOMET-XL --token "$HF_TOKEN" --output /path/to/converted/XCOMET-XL
 ```
 
 Then use the converted model directory in your training config with:
 
-- `valid_metrics: ["EOLE-COMET"]` or `valid_metrics: ["EOLE-COMET-KIWI"]`
+- `valid_metrics: ["EOLE-COMET"]`, `valid_metrics: ["EOLE-COMET-KIWI"]`, or `valid_metrics: ["EOLE-XCOMET"]`
 - `comet_model: /path/to/converted/model`
+
+`eole predict --with_score` emits scalar scores for converted scorer models. For
+XCOMET, explainable span parity can be validated with the
+`recipes/scoring/comet_native/parity_check.py` harness.

--- a/eole/bin/convert/convert_COMET.py
+++ b/eole/bin/convert/convert_COMET.py
@@ -21,7 +21,7 @@ def _slug(name):
 
 
 def _validate_class_identifier(class_identifier):
-    if class_identifier in ["regression_metric", "referenceless_regression_metric", "unified_metric"]:
+    if class_identifier in ["regression_metric", "referenceless_regression_metric", "unified_metric", "xcomet_metric"]:
         return
     raise ValueError(f"Unsupported COMET class_identifier: {class_identifier}")
 
@@ -88,7 +88,7 @@ def _build_model_config(args_model, hparams, encoder_config):
     input_segments = hparams.get("input_segments", ["mt", "src", "ref"])
     class_identifier = hparams["class_identifier"]
     requires_reference = class_identifier == "regression_metric" or (
-        class_identifier == "unified_metric" and "ref" in input_segments
+        class_identifier in {"unified_metric", "xcomet_metric"} and "ref" in input_segments
     )
 
     return {
@@ -102,6 +102,11 @@ def _build_model_config(args_model, hparams, encoder_config):
         "layer_transformation": layer_transformation,
         "layer_norm": bool(hparams.get("layer_norm", False)),
         "input_segments": input_segments,
+        "word_layer": hparams.get("word_layer"),
+        "error_labels": hparams.get("error_labels", ["minor", "major", "critical"]),
+        "input_weights_spans": hparams.get("input_weights_spans", [0.1667, 0.3333, 0.5]),
+        "score_weights": hparams.get("score_weights", [0.12, 0.33, 0.33, 0.22]),
+        "decoding_threshold": hparams.get("decoding_threshold"),
         "hidden_sizes": hparams.get("hidden_sizes", [3072, 1024]),
         "activations": hparams.get("activations", "Tanh"),
         "final_activation": hparams.get("final_activation"),
@@ -201,6 +206,8 @@ def _convert_state_dict(state_dict, model_config):
     for key, value in state_dict.items():
         if key.startswith("estimator."):
             converted[key] = value
+        elif key.startswith("hidden2tag."):
+            converted[key] = value
         elif (
             key.startswith("layerwise_attention.")
             and not key.endswith("dropout_mask")
@@ -254,6 +261,10 @@ class CometConverter(BaseBin):
         converted = _convert_state_dict(state_dict, model_config)
         if not any(key.startswith("estimator.") for key in converted):
             raise ValueError("Converted checkpoint is missing estimator.* weights.")
+        if model_config["class_identifier"] == "xcomet_metric" and not any(
+            key.startswith("hidden2tag.") for key in converted
+        ):
+            raise ValueError("Converted xCOMET checkpoint is missing hidden2tag.* weights.")
 
         for obsolete in ["model.ckpt", "eole_comet_config.json"]:
             path = os.path.join(output_dir, obsolete)

--- a/eole/bin/convert/convert_COMET.py
+++ b/eole/bin/convert/convert_COMET.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+import json
+import os
+import shutil
+from types import SimpleNamespace
+
+import torch
+import yaml
+from huggingface_hub import snapshot_download
+from safetensors.torch import save_file
+
+from eole.bin import BaseBin, register_bin
+from eole.bin.convert.convert_HF import check_sentencepiece_tokenizer, check_special_tokens, save_vocab
+
+
+SUPPORTED_ENCODERS = {"XLMRobertaForMaskedLM", "XLMRobertaXLForMaskedLM"}
+
+
+def _slug(name):
+    return name.replace("/", "--")
+
+
+def _validate_class_identifier(class_identifier):
+    if class_identifier in ["regression_metric", "referenceless_regression_metric", "unified_metric"]:
+        return
+    raise ValueError(f"Unsupported COMET class_identifier: {class_identifier}")
+
+
+def _copy_tokenizer_assets(src_dir, output_dir):
+    for filename in [
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "sentencepiece.bpe.model",
+        "sentencepiece.model",
+    ]:
+        src = os.path.join(src_dir, filename)
+        dst = os.path.join(output_dir, filename)
+        if os.path.exists(src):
+            shutil.copyfile(src, dst)
+
+
+def _build_vocab(encoder_snapshot, output_dir, token):
+    tokenizer_model = None
+    for filename in ["sentencepiece.bpe.model", "sentencepiece.model"]:
+        path = os.path.join(encoder_snapshot, filename)
+        if os.path.exists(path):
+            tokenizer_model = path
+            break
+    tokenizer_json_path = os.path.join(encoder_snapshot, "tokenizer.json")
+    tokenizer_json = None
+    if os.path.exists(tokenizer_json_path):
+        with open(tokenizer_json_path, encoding="utf-8") as f:
+            tokenizer_json = json.load(f)
+    special_tokens_path = os.path.join(encoder_snapshot, "special_tokens_map.json")
+    special_tokens = None
+    if os.path.exists(special_tokens_path):
+        with open(special_tokens_path, encoding="utf-8") as f:
+            special_tokens = json.load(f)
+
+    if tokenizer_model is not None:
+        hf = SimpleNamespace(tokenizer_model=tokenizer_model, tokenizer=tokenizer_json, tokenizer_json=tokenizer_json)
+        src_vocab, _ = check_sentencepiece_tokenizer(hf)
+    else:
+        raise FileNotFoundError(f"No sentencepiece model found in {encoder_snapshot}")
+
+    if special_tokens is not None:
+        hf_for_specials = SimpleNamespace(special_tokens=special_tokens, tokenizer_config=None)
+        vocabs = check_special_tokens(hf_for_specials)
+    else:
+        vocabs = {"specials": {"bos_token": "<s>", "pad_token": "<pad>", "eos_token": "</s>", "unk_token": "<unk>"}}
+    save_vocab(vocabs, src_vocab, output_dir)
+
+
+def _build_model_config(args_model, hparams, encoder_config):
+    encoder_architecture = encoder_config["architectures"][0]
+    if encoder_architecture not in SUPPORTED_ENCODERS:
+        raise ValueError(
+            f"Unsupported COMET encoder architecture: {encoder_architecture}. "
+            "Native COMET conversion currently supports only XLM-R/XLM-R-XL."
+        )
+
+    layer_transformation = hparams.get("layer_transformation", "softmax")
+    if layer_transformation == "sparsemax_patch":
+        layer_transformation = "softmax"
+
+    input_segments = hparams.get("input_segments", ["mt", "src", "ref"])
+    class_identifier = hparams["class_identifier"]
+    requires_reference = class_identifier == "regression_metric" or (
+        class_identifier == "unified_metric" and "ref" in input_segments
+    )
+
+    return {
+        "architecture": "transformer_encoder_scorer",
+        "scoring_type": "comet",
+        "class_identifier": class_identifier,
+        "requires_reference": requires_reference,
+        "pretrained_model": args_model,
+        "pool": hparams.get("pool", "avg"),
+        "layer": str(hparams.get("sent_layer", hparams.get("layer", "mix"))),
+        "layer_transformation": layer_transformation,
+        "layer_norm": bool(hparams.get("layer_norm", False)),
+        "input_segments": input_segments,
+        "hidden_sizes": hparams.get("hidden_sizes", [3072, 1024]),
+        "activations": hparams.get("activations", "Tanh"),
+        "final_activation": hparams.get("final_activation"),
+        "dropout": float(hparams.get("dropout", 0.1)),
+        "encoder_architecture": encoder_architecture,
+        "embeddings": {
+            "embedding_type": "roberta",
+            "src_word_vec_size": encoder_config["hidden_size"],
+            "tgt_word_vec_size": encoder_config["hidden_size"],
+            "word_vec_size": encoder_config["hidden_size"],
+            "position_encoding_type": "Learned",
+            "n_positions": encoder_config.get("max_position_embeddings", 514),
+            "position_shift": 2 if encoder_architecture == "XLMRobertaXLForMaskedLM" else 0,
+            "embedding_layer_norm": encoder_architecture != "XLMRobertaXLForMaskedLM",
+            "token_type_vocab_size": 1,
+        },
+        "encoder": {
+            "encoder_type": "transformer",
+            "layers": encoder_config["num_hidden_layers"],
+            "hidden_size": encoder_config["hidden_size"],
+            "heads": encoder_config["num_attention_heads"],
+            "transformer_ff": encoder_config["intermediate_size"],
+            "mlp_activation_fn": "gelu",
+            "layer_norm": "standard",
+            "norm_eps": encoder_config.get("layer_norm_eps", 1e-5),
+            "add_qkvbias": True,
+            "add_key_bias": True,
+            "add_final_linear_bias": True,
+            "add_ffnbias": True,
+            "position_encoding_type": "Learned",
+            "n_positions": encoder_config.get("max_position_embeddings", 514),
+            "encoder_layer_style": "standard" if encoder_architecture == "XLMRobertaXLForMaskedLM" else "postnorm",
+            "final_encoder_layer_norm": encoder_architecture == "XLMRobertaXLForMaskedLM",
+        },
+    }
+
+
+def _convert_state_dict(state_dict, model_config):
+    encoder_cfg = model_config["encoder"]
+    embeddings_cfg = model_config["embeddings"]
+    converted = {
+        "encoder.embeddings.word_embeddings.weight": state_dict["encoder.model.embeddings.word_embeddings.weight"],
+        "encoder.embeddings.position_embeddings.weight": state_dict[
+            "encoder.model.embeddings.position_embeddings.weight"
+        ],
+        "encoder.embeddings.token_type_embeddings.weight": state_dict[
+            "encoder.model.embeddings.token_type_embeddings.weight"
+        ],
+    }
+    if embeddings_cfg.get("embedding_layer_norm", False):
+        converted["encoder.embeddings.layer_norm.weight"] = state_dict["encoder.model.embeddings.LayerNorm.weight"]
+        converted["encoder.embeddings.layer_norm.bias"] = state_dict["encoder.model.embeddings.LayerNorm.bias"]
+    if encoder_cfg.get("final_encoder_layer_norm", False):
+        converted["encoder.layer_norm.weight"] = state_dict["encoder.model.encoder.LayerNorm.weight"]
+        converted["encoder.layer_norm.bias"] = state_dict["encoder.model.encoder.LayerNorm.bias"]
+
+    layers = encoder_cfg["layers"]
+    is_xl = model_config["encoder_architecture"] == "XLMRobertaXLForMaskedLM"
+    for i in range(layers):
+        src_prefix = f"encoder.model.encoder.layer.{i}."
+        dst_prefix = f"encoder.transformer_layers.{i}."
+        converted[dst_prefix + "self_attn.linear_query.weight"] = state_dict[src_prefix + "attention.self.query.weight"]
+        converted[dst_prefix + "self_attn.linear_query.bias"] = state_dict[src_prefix + "attention.self.query.bias"]
+        converted[dst_prefix + "self_attn.linear_keys.weight"] = state_dict[src_prefix + "attention.self.key.weight"]
+        converted[dst_prefix + "self_attn.linear_keys.bias"] = state_dict[src_prefix + "attention.self.key.bias"]
+        converted[dst_prefix + "self_attn.linear_values.weight"] = state_dict[
+            src_prefix + "attention.self.value.weight"
+        ]
+        converted[dst_prefix + "self_attn.linear_values.bias"] = state_dict[src_prefix + "attention.self.value.bias"]
+        converted[dst_prefix + "self_attn.final_linear.weight"] = state_dict[
+            src_prefix + "attention.output.dense.weight"
+        ]
+        converted[dst_prefix + "self_attn.final_linear.bias"] = state_dict[src_prefix + "attention.output.dense.bias"]
+        if is_xl:
+            converted[dst_prefix + "input_layernorm.weight"] = state_dict[
+                src_prefix + "attention.self_attn_layer_norm.weight"
+            ]
+            converted[dst_prefix + "input_layernorm.bias"] = state_dict[
+                src_prefix + "attention.self_attn_layer_norm.bias"
+            ]
+            converted[dst_prefix + "post_attention_layernorm.weight"] = state_dict[src_prefix + "LayerNorm.weight"]
+            converted[dst_prefix + "post_attention_layernorm.bias"] = state_dict[src_prefix + "LayerNorm.bias"]
+        else:
+            converted[dst_prefix + "attention_layer_norm.weight"] = state_dict[
+                src_prefix + "attention.output.LayerNorm.weight"
+            ]
+            converted[dst_prefix + "attention_layer_norm.bias"] = state_dict[
+                src_prefix + "attention.output.LayerNorm.bias"
+            ]
+            converted[dst_prefix + "output_layer_norm.weight"] = state_dict[src_prefix + "output.LayerNorm.weight"]
+            converted[dst_prefix + "output_layer_norm.bias"] = state_dict[src_prefix + "output.LayerNorm.bias"]
+        converted[dst_prefix + "mlp.gate_up_proj.weight"] = state_dict[src_prefix + "intermediate.dense.weight"]
+        converted[dst_prefix + "mlp.gate_up_proj.bias"] = state_dict[src_prefix + "intermediate.dense.bias"]
+        converted[dst_prefix + "mlp.down_proj.weight"] = state_dict[src_prefix + "output.dense.weight"]
+        converted[dst_prefix + "mlp.down_proj.bias"] = state_dict[src_prefix + "output.dense.bias"]
+
+    for key, value in state_dict.items():
+        if key.startswith("estimator."):
+            converted[key] = value
+        elif (
+            key.startswith("layerwise_attention.")
+            and not key.endswith("dropout_mask")
+            and not key.endswith("dropout_fill")
+        ):
+            converted[key] = value
+    return converted
+
+
+@register_bin(name="COMET")
+class CometConverter(BaseBin):
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument("--model", type=str, required=True, help="COMET HF model id")
+        parser.add_argument("--output", type=str, required=False, help="Output directory for converted model")
+        parser.add_argument("--token", type=str, default=None, help="Hugging Face token for gated models")
+
+    @classmethod
+    def run(cls, args):
+        model_root = os.environ.get("EOLE_MODEL_DIR")
+        default_output = os.path.join(model_root, "comet", _slug(args.model)) if model_root else _slug(args.model)
+        output_dir = args.output or default_output
+        os.makedirs(output_dir, exist_ok=True)
+
+        snapshot_dir = snapshot_download(repo_id=args.model, token=args.token)
+        model_ckpt = os.path.join(snapshot_dir, "checkpoints", "model.ckpt")
+        hparams_file = os.path.join(snapshot_dir, "hparams.yaml")
+        if not os.path.exists(model_ckpt) or not os.path.exists(hparams_file):
+            raise FileNotFoundError("Could not find COMET checkpoint files (hparams.yaml and checkpoints/model.ckpt).")
+
+        with open(hparams_file, encoding="utf-8") as f:
+            hparams = yaml.safe_load(f)
+        _validate_class_identifier(hparams["class_identifier"])
+
+        encoder_snapshot = snapshot_download(repo_id=hparams["pretrained_model"], token=args.token)
+        with open(os.path.join(encoder_snapshot, "config.json"), encoding="utf-8") as f:
+            encoder_config = json.load(f)
+
+        model_config = _build_model_config(args.model, hparams, encoder_config)
+        train_config = {
+            "src_vocab": "dummy",
+            "tgt_vocab": "dummy",
+            "data": {},
+            "share_vocab": True,
+            "training": {"compute_dtype": "fp32"},
+            "model": model_config,
+        }
+
+        ckpt = torch.load(model_ckpt, map_location="cpu")
+        state_dict = ckpt.get("state_dict", ckpt)
+        converted = _convert_state_dict(state_dict, model_config)
+        if not any(key.startswith("estimator.") for key in converted):
+            raise ValueError("Converted checkpoint is missing estimator.* weights.")
+
+        for obsolete in ["model.ckpt", "eole_comet_config.json"]:
+            path = os.path.join(output_dir, obsolete)
+            if os.path.exists(path):
+                os.remove(path)
+
+        _copy_tokenizer_assets(encoder_snapshot, output_dir)
+        _build_vocab(encoder_snapshot, output_dir, args.token)
+        save_file(converted, os.path.join(output_dir, "model.00.safetensors"))
+
+        with open(os.path.join(output_dir, "config.json"), "w", encoding="utf-8") as f:
+            json.dump(train_config, f, indent=2)
+
+        print(f"Converted COMET model written to: {output_dir}")

--- a/eole/config/common.py
+++ b/eole/config/common.py
@@ -113,6 +113,13 @@ class LoggingConfig(Config):
         default=64,
         description="Batch size used when running COMET/COMET-KIWI scoring.",
     )
+    comet_device: str | None = Field(
+        default=None,
+        description=(
+            "Device used for COMET/EOLE-COMET scoring (for example: 'cpu', 'mps', 'cuda', 'cuda:0'). "
+            "When unset, EOLE picks cuda, then mps, then cpu."
+        ),
+    )
     scoring_debug: bool = Field(default=False, description="Dump src/ref/pred of the current batch.")
     dump_preds: str | None = Field(default=None, description="Folder to dump predictions to.")
     tensorboard: bool = Field(default=False, description="Use tensorboard for visualization during training.")

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -52,7 +52,10 @@ class EmbeddingsConfig(Config):
     )
     token_type_vocab_size: int = Field(
         default=0,
-        description="Token type vocabulary size for embedding block. 0 disables token type embeddings.",
+        description=(
+            "Token type vocabulary size for RoBERTa-style embedding block. "
+            "Values below 1 are treated as 1, matching all-zero token type ids."
+        ),
     )
 
     @model_validator(mode="after")
@@ -1107,15 +1110,20 @@ class TransformerEncoderScorerModelConfig(BaseModelConfig):
 
     scoring_type: Literal["comet", "pooled_regression"] = Field(default="comet")
     pretrained_model: str = Field(default="xlm-roberta-large")
-    class_identifier: Literal["regression_metric", "referenceless_regression_metric", "unified_metric"] = Field(
-        default="regression_metric"
-    )
+    class_identifier: Literal[
+        "regression_metric", "referenceless_regression_metric", "unified_metric", "xcomet_metric"
+    ] = Field(default="regression_metric")
     requires_reference: bool = Field(default=True)
     pool: Literal["avg", "max", "cls"] = Field(default="avg")
     layer: str = Field(default="mix")
     layer_transformation: Literal["softmax", "sparsemax"] = Field(default="softmax")
     layer_norm: bool = Field(default=False)
     input_segments: List[str] = Field(default_factory=lambda: ["mt", "src", "ref"])
+    word_layer: int | None = Field(default=None)
+    error_labels: List[str] = Field(default_factory=lambda: ["minor", "major", "critical"])
+    input_weights_spans: List[float] = Field(default_factory=lambda: [0.1667, 0.3333, 0.5])
+    score_weights: List[float] = Field(default_factory=lambda: [0.12, 0.33, 0.33, 0.22])
+    decoding_threshold: float | None = Field(default=None)
     hidden_sizes: List[int] = Field(default_factory=lambda: [3072, 1024])
     activations: str = Field(default="Tanh")
     final_activation: str | None = Field(default=None)
@@ -1149,10 +1157,17 @@ class TransformerEncoderScorerModelConfig(BaseModelConfig):
     def sync_family_fields(self):
         if self.scoring_type == "comet":
             expected_requires_reference = self.class_identifier == "regression_metric" or (
-                self.class_identifier == "unified_metric" and "ref" in self.input_segments
+                self.class_identifier in {"unified_metric", "xcomet_metric"} and "ref" in self.input_segments
             )
             if self.requires_reference != expected_requires_reference:
-                self.requires_reference = expected_requires_reference
+                object.__setattr__(self, "requires_reference", expected_requires_reference)
+            if self.class_identifier == "xcomet_metric":
+                if self.error_labels != ["minor", "major", "critical"]:
+                    raise ValueError("xcomet_metric expects error_labels=['minor', 'major', 'critical'].")
+                if len(self.input_weights_spans) != 3:
+                    raise ValueError("xcomet_metric expects exactly 3 input_weights_spans values.")
+                if len(self.score_weights) != 4:
+                    raise ValueError("xcomet_metric expects exactly 4 score_weights values.")
         elif self.scoring_type == "pooled_regression":
             if len(self.input_segments) != 1:
                 raise ValueError("pooled_regression expects exactly one input segment.")

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -13,6 +13,7 @@ from eole.config.config import Config
 
 
 class EmbeddingsConfig(Config):
+    embedding_type: Literal["standard", "roberta"] = Field(default="standard", description="Embedding block type.")
     src_word_vec_size: int = Field(default=512, description="Word embedding size for src.")
     tgt_word_vec_size: int = Field(default=512, description="Word embedding size for tgt.")
     word_vec_size: int = Field(default=-1, description="Word embedding size for src and tgt.")
@@ -44,6 +45,14 @@ class EmbeddingsConfig(Config):
         description="Enable embeddings scaling. "
         "Not always necessary, but useful for some model compatibility, e.g. gemma. "
         "https://datascience.stackexchange.com/a/87909",
+    )
+    embedding_layer_norm: bool = Field(
+        default=False,
+        description="Apply LayerNorm in embedding block (RoBERTa/XLM-R style).",
+    )
+    token_type_vocab_size: int = Field(
+        default=0,
+        description="Token type vocabulary size for embedding block. 0 disables token type embeddings.",
     )
 
     @model_validator(mode="after")
@@ -373,6 +382,14 @@ class TransformerEncoderConfig(TransformerConfig, EncoderConfig):
     encoder_type: Literal["transformer"] = Field(
         default="transformer"
     )  # not sure it's fully proper use, but inspired from docs -- https://docs.pydantic.dev/latest/concepts/fields/#discriminator # noqa: E501
+    encoder_layer_style: Literal["standard", "postnorm", "roberta"] = Field(
+        default="standard",
+        description="Encoder layer style: standard pre-norm or post-norm (RoBERTa/XLM-R).",
+    )
+    final_encoder_layer_norm: bool = Field(
+        default=True,
+        description="Apply final encoder LayerNorm after all layers.",
+    )
 
 
 class TransformerDecoderConfig(TransformerConfig, DecoderConfig):
@@ -1076,6 +1093,76 @@ class TransformerEncoderModelConfig(TransformerConfig, BaseModelConfig):
         return self
 
 
+class TransformerEncoderScorerModelConfig(BaseModelConfig):
+    architecture: Literal["transformer_encoder_scorer"] = Field(default="transformer_encoder_scorer")
+    encoder: TransformerEncoderConfig | None = Field(
+        default_factory=TransformerEncoderConfig,
+        description="Transformer encoder settings for encoder scorer models.",
+    )
+    decoder: None = Field(default=None, description="Encoder scorer models do not use a decoder.")
+    embeddings: EmbeddingsConfig = Field(
+        default_factory=EmbeddingsConfig,
+        description="Embedding settings for encoder scorer models.",
+    )
+
+    scoring_type: Literal["comet", "pooled_regression"] = Field(default="comet")
+    pretrained_model: str = Field(default="xlm-roberta-large")
+    class_identifier: Literal["regression_metric", "referenceless_regression_metric", "unified_metric"] = Field(
+        default="regression_metric"
+    )
+    requires_reference: bool = Field(default=True)
+    pool: Literal["avg", "max", "cls"] = Field(default="avg")
+    layer: str = Field(default="mix")
+    layer_transformation: Literal["softmax", "sparsemax"] = Field(default="softmax")
+    layer_norm: bool = Field(default=False)
+    input_segments: List[str] = Field(default_factory=lambda: ["mt", "src", "ref"])
+    hidden_sizes: List[int] = Field(default_factory=lambda: [3072, 1024])
+    activations: str = Field(default="Tanh")
+    final_activation: str | None = Field(default=None)
+    dropout: float = Field(default=0.1)
+    norm_eps: float = Field(default=1e-5)
+    encoder_architecture: Literal["XLMRobertaForMaskedLM", "XLMRobertaXLForMaskedLM"] = Field(
+        default="XLMRobertaForMaskedLM"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def encoder_decoder_type(cls, data: Any) -> Any:
+        if not (isinstance(data, dict)):
+            return data
+        if "encoder" in data.keys():
+            data["encoder"]["encoder_type"] = "transformer"
+        else:
+            data["encoder"] = {"encoder_type": "transformer"}
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def default_architecture(cls, data: Any) -> Any:
+        if not (isinstance(data, dict)):
+            return data
+        if "architecture" not in data.keys():
+            data["architecture"] = "transformer_encoder_scorer"
+        return data
+
+    @model_validator(mode="after")
+    def sync_family_fields(self):
+        if self.scoring_type == "comet":
+            expected_requires_reference = self.class_identifier == "regression_metric" or (
+                self.class_identifier == "unified_metric" and "ref" in self.input_segments
+            )
+            if self.requires_reference != expected_requires_reference:
+                self.requires_reference = expected_requires_reference
+        elif self.scoring_type == "pooled_regression":
+            if len(self.input_segments) != 1:
+                raise ValueError("pooled_regression expects exactly one input segment.")
+            if self.class_identifier == "unified_metric":
+                raise ValueError("pooled_regression does not support class_identifier='unified_metric'.")
+            if self.requires_reference:
+                raise ValueError("pooled_regression should set requires_reference=false.")
+        return self
+
+
 # Facilitate transparent instanciation from dumped fields
 # https://stackoverflow.com/a/76538571
 ModelConfig = Annotated[
@@ -1085,6 +1172,7 @@ ModelConfig = Annotated[
         VisionTransformerLMModelConfig,
         WhisperModelConfig,
         TransformerEncoderModelConfig,
+        TransformerEncoderScorerModelConfig,
         RnnModelConfig,
         CnnModelConfig,
         CustomModelConfig,

--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -133,6 +133,10 @@ class PredictConfig(
         default=None,
         description="Reference target sequences for reference-based scoring models.",
     )
+    score_level: Literal["segment", "system"] = Field(
+        default="segment",
+        description="Score output granularity for scorer predictors: segment scores or one aggregate system score.",
+    )
     tgt_file_prefix: bool = Field(default=False, description="Generate predictions using provided tgt as prefix.")
     output: str = Field(
         default="pred.txt",

--- a/eole/config/run.py
+++ b/eole/config/run.py
@@ -129,6 +129,10 @@ class PredictConfig(
         default=None,
         description="True target sequences, useful for scoring or prefix decoding.",
     )
+    ref: str | None = Field(
+        default=None,
+        description="Reference target sequences for reference-based scoring models.",
+    )
     tgt_file_prefix: bool = Field(default=False, description="Generate predictions using provided tgt as prefix.")
     output: str = Field(
         default="pred.txt",

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -1,6 +1,6 @@
 """Implementation of Transformer Encoder from 'Attention is All You Need'"""
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
@@ -23,28 +23,40 @@ class TransformerEncoderLayer(nn.Module):
     def __init__(self, encoder_config, running_config=None):
         super().__init__()
 
+        layer_style = getattr(encoder_config, "encoder_layer_style", "standard")
+        self.postnorm_style = layer_style in {"postnorm", "roberta"}
         self.parallel_residual = encoder_config.parallel_residual
         self.ffn_layernorm = encoder_config.ffn_layernorm
         self.dropout_p = getattr(running_config, "dropout", [0.0])[0] if running_config else 0.0
 
         # Layer components
-        self.input_layernorm = LayerNorm[encoder_config.layer_norm](
-            encoder_config.hidden_size, eps=encoder_config.norm_eps
-        )
+        if not self.postnorm_style:
+            self.input_layernorm = LayerNorm[encoder_config.layer_norm](
+                encoder_config.hidden_size, eps=encoder_config.norm_eps
+            )
         self.self_attn = SelfMHA(
             encoder_config,
             running_config=running_config,
             is_decoder=False,
         )
         self.dropout = nn.Dropout(self.dropout_p)
-        self.post_attention_layernorm = LayerNorm[encoder_config.layer_norm](
-            encoder_config.hidden_size, eps=encoder_config.norm_eps
-        )
+        if self.postnorm_style:
+            self.attention_layer_norm = LayerNorm[encoder_config.layer_norm](
+                encoder_config.hidden_size, eps=encoder_config.norm_eps
+            )
+        else:
+            self.post_attention_layernorm = LayerNorm[encoder_config.layer_norm](
+                encoder_config.hidden_size, eps=encoder_config.norm_eps
+            )
         if self.ffn_layernorm:
             self.pre_feedforward_layernorm = LayerNorm[encoder_config.layer_norm](
                 encoder_config.hidden_size, eps=encoder_config.norm_eps
             )
             self.post_feedforward_layernorm = LayerNorm[encoder_config.layer_norm](
+                encoder_config.hidden_size, eps=encoder_config.norm_eps
+            )
+        elif self.postnorm_style:
+            self.output_layer_norm = LayerNorm[encoder_config.layer_norm](
                 encoder_config.hidden_size, eps=encoder_config.norm_eps
             )
         self.mlp = MLP(encoder_config, running_config=running_config)
@@ -66,14 +78,21 @@ class TransformerEncoderLayer(nn.Module):
         Returns:
             Output tensor (batch_size, src_len, model_dim)
         """
-        norm_layer_in = self.input_layernorm(layer_in)
+        if self.postnorm_style:
+            attn_in = layer_in
+        else:
+            attn_in = self.input_layernorm(layer_in)
         self_attn, _ = self.self_attn(
-            norm_layer_in,
+            attn_in,
             attn_mask=attn_mask,
             position_embeddings=position_embeddings,
         )
         if self.dropout_p > 0:
             self_attn = self.dropout(self_attn)
+
+        if self.postnorm_style and not self.ffn_layernorm:
+            attn_out = self.attention_layer_norm(layer_in + self_attn)
+            return self.output_layer_norm(attn_out + self.mlp(attn_out))
 
         if self.ffn_layernorm:
             # Gemma4-style: post_attention_layernorm applied to attn output BEFORE residual,
@@ -88,7 +107,7 @@ class TransformerEncoderLayer(nn.Module):
         self_attn.add_(layer_in)
 
         # prepare feed-forward input
-        ff_in = self.post_attention_layernorm(self_attn) if not self.parallel_residual else norm_layer_in
+        ff_in = self.post_attention_layernorm(self_attn) if not self.parallel_residual else attn_in
 
         # add residual after mlp
         return self_attn + self.mlp(ff_in)
@@ -120,11 +139,16 @@ class TransformerEncoder(EncoderBase):
         self.transformer_layers = nn.ModuleList(
             [TransformerEncoderLayer(encoder_config, running_config) for _ in range(encoder_config.layers)]
         )
-        self.layer_norm = LayerNorm[encoder_config.layer_norm](encoder_config.hidden_size, eps=encoder_config.norm_eps)
+        if getattr(encoder_config, "final_encoder_layer_norm", True):
+            self.layer_norm = LayerNorm[encoder_config.layer_norm](
+                encoder_config.hidden_size, eps=encoder_config.norm_eps
+            )
+        else:
+            self.layer_norm = None
 
     def forward(
-        self, emb: torch.Tensor, pad_mask: Optional[torch.Tensor] = None, **kwargs
-    ) -> Tuple[torch.Tensor, None]:
+        self, emb: torch.Tensor, pad_mask: Optional[torch.Tensor] = None, return_hidden_states: bool = False, **kwargs
+    ) -> Union[Tuple[torch.Tensor, None], Tuple[torch.Tensor, None, list[torch.Tensor]]]:
         """
         Encode input embeddings.
 
@@ -136,9 +160,10 @@ class TransformerEncoder(EncoderBase):
             **kwargs: Additional arguments (ignored)
 
         Returns:
-            Tuple of:
-                - Encoded output (batch_size, src_len, model_dim)
-                - None (transformers don't return final state)
+            If ``return_hidden_states`` is ``False``:
+                - (encoded_output, None)
+            If ``return_hidden_states`` is ``True``:
+                - (encoded_output, None, hidden_states)
 
         Raises:
             ValueError: If pad_mask is not provided
@@ -153,10 +178,16 @@ class TransformerEncoder(EncoderBase):
         pad_mask = pad_mask.unsqueeze(1)
         attn_mask = ~pad_mask
 
+        hidden_states = [emb] if return_hidden_states else None
         for layer in self.transformer_layers:
             emb = layer(emb, attn_mask, position_embeddings=position_embeddings)
+            if hidden_states is not None:
+                hidden_states.append(emb)
 
-        output = self.layer_norm(emb)
+        output = self.layer_norm(emb) if self.layer_norm is not None else emb
+        if hidden_states is not None:
+            hidden_states[-1] = output
+            return output, None, hidden_states
         return output, None
 
     def update_dropout(self, dropout: float, attention_dropout: float) -> None:

--- a/eole/encoders/transformer.py
+++ b/eole/encoders/transformer.py
@@ -40,7 +40,7 @@ class TransformerEncoderLayer(nn.Module):
             is_decoder=False,
         )
         self.dropout = nn.Dropout(self.dropout_p)
-        if self.postnorm_style:
+        if self.postnorm_style and not self.ffn_layernorm:
             self.attention_layer_norm = LayerNorm[encoder_config.layer_norm](
                 encoder_config.hidden_size, eps=encoder_config.norm_eps
             )

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -4,6 +4,7 @@ from glob import glob
 from collections import defaultdict
 import os
 import itertools
+from safetensors.torch import load_file
 
 from eole.utils.logging import logger
 
@@ -23,9 +24,10 @@ from eole.encoders import str2enc
 from eole.decoders import str2dec
 from eole.adapters import str2adapter
 from eole.constants import DefaultTokens, LayerNormFP32
-from eole.modules.embeddings import Embeddings
+from eole.modules.embeddings import Embeddings, RobertaEmbeddings
 from eole.models.model_saver import get_metadata, TP_COL_PARALLEL_LAYERS, TP_ROW_PARALLEL_LAYERS
 from eole.modules.estimator import FeedForward
+from eole.modules.representation import LayerwiseAttention, RepresentationExtractor
 
 from eole.encoders.vision import VisionEncoder
 from eole.encoders.audio import AudioEncoder
@@ -69,18 +71,30 @@ def build_decoder(model_config, running_config=None):
 def build_src_emb(model_config, vocabs, running_config=None):
     # Build embeddings.
     pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
-    src_emb = Embeddings(
-        word_vec_size=model_config.embeddings.src_word_vec_size,
-        position_encoding_type=model_config.embeddings.position_encoding_type,
-        position_shift=model_config.embeddings.position_shift,
-        dropout=getattr(running_config, "dropout", [0.0])[0],
-        word_padding_idx=vocabs["tgt"][pad_token],
-        word_vocab_size=len(vocabs["src"]),
-        sparse=getattr(running_config, "optim", None) == "sparseadam",
-        freeze_word_vecs=model_config.embeddings.freeze_word_vecs_enc,
-        n_positions=model_config.embeddings.n_positions,
-        normalize=model_config.embeddings.normalize,
-    )
+    if getattr(model_config.embeddings, "embedding_type", "standard") == "roberta":
+        src_emb = RobertaEmbeddings(
+            word_vec_size=model_config.embeddings.src_word_vec_size,
+            word_padding_idx=vocabs["tgt"][pad_token],
+            word_vocab_size=len(vocabs["src"]),
+            dropout=getattr(running_config, "dropout", [0.0])[0],
+            n_positions=model_config.embeddings.n_positions,
+            token_type_vocab_size=max(1, getattr(model_config.embeddings, "token_type_vocab_size", 0)),
+            embedding_layer_norm=getattr(model_config.embeddings, "embedding_layer_norm", False),
+            norm_eps=model_config.norm_eps,
+        )
+    else:
+        src_emb = Embeddings(
+            word_vec_size=model_config.embeddings.src_word_vec_size,
+            position_encoding_type=model_config.embeddings.position_encoding_type,
+            position_shift=model_config.embeddings.position_shift,
+            dropout=getattr(running_config, "dropout", [0.0])[0],
+            word_padding_idx=vocabs["tgt"][pad_token],
+            word_vocab_size=len(vocabs["src"]),
+            sparse=getattr(running_config, "optim", None) == "sparseadam",
+            freeze_word_vecs=model_config.embeddings.freeze_word_vecs_enc,
+            n_positions=model_config.embeddings.n_positions,
+            normalize=model_config.embeddings.normalize,
+        )
     return src_emb
 
 
@@ -590,19 +604,25 @@ class BaseModel(nn.Module):
             else:
                 param.data = sliced.contiguous()
 
+    def _checkpoint_key_for_param(self, full_name):
+        return full_name
+
     def _try_load_parameter(
         self, module_name, module, param_name, param, f, keys_shard, updated_params, buf_list, keyfound, tp_offset
     ):
         """Try to load a parameter from updated_params or keys_shard."""
         # in the case of "adapter.new_line" adapter is not a module hence module_name is ""
         full_name = f"{module_name}.{param_name}" if module_name else f"{param_name}"
+        checkpoint_name = self._checkpoint_key_for_param(full_name)
         ckpt_t = updated_params.get(full_name)
-        if ckpt_t is None and full_name in keys_shard:
-            ckpt_t = f[keys_shard[full_name]].get_tensor(full_name)
+        loaded_name = full_name
+        if ckpt_t is None and checkpoint_name in keys_shard:
+            ckpt_t = f[keys_shard[checkpoint_name]].get_tensor(checkpoint_name)
+            loaded_name = checkpoint_name
         if ckpt_t is None:
             return False
         self._load_param(module_name, module, param_name, param, buf_list, ckpt_t, tp_offset)
-        keyfound[full_name] = True
+        keyfound[loaded_name] = True
         return True
 
     def _maybe_warn_missing_parameter(self, module_name, param_name, module, buffers_list):
@@ -743,6 +763,7 @@ class BaseModel(nn.Module):
         # so we load the weights  module by module and transfer them to GPU for quantization
         dtype = getattr(running_config, "storage_dtype", torch.float32)
         f, keys_shard = self._load_safetensors_shards(model_path)
+        self._last_loaded_checkpoint_keys = set(keys_shard)
         if device == torch.device("cpu"):
             tp_offset = 0
         buf_list = [name for name, _ in self.named_buffers()]
@@ -753,6 +774,7 @@ class BaseModel(nn.Module):
         self._report_extra_keys(keys_shard, keyfound, buf_list)
         self._reset_lora_to_fp32()
         self._reset_invfreq_to_fp32(buf_list)
+        return keyfound
 
     def count_parameters(self, log=print):
         """Count number of parameters in model (& print with `log` callback).
@@ -996,6 +1018,264 @@ class EncoderModel(BaseModel):
 
     def update_dropout(self, dropout, attention_dropout):
         self.encoder.update_dropout(dropout, attention_dropout)
+
+
+class EncoderScoringModel(BaseModel):
+    def __init__(self, model_config, encoder, src_emb, device=None, vocabs=None):
+        src_vocab = vocabs["src"]
+        specials = vocabs["specials"]
+        pad_token = specials["pad_token"]
+        bos_token = specials["bos_token"]
+        eos_token = specials["eos_token"]
+        super(EncoderScoringModel, self).__init__(
+            encoder=encoder,
+            src_emb=src_emb,
+            hidden_size=model_config.encoder.hidden_size,
+        )
+        self.model_config = model_config
+        self.vocabs = vocabs
+        self.device = torch.device(device) if device is not None else get_device()
+        self.scoring_type = getattr(model_config, "scoring_type", "comet")
+        self.class_identifier = getattr(model_config, "class_identifier", "regression_metric")
+        self.input_segments = list(getattr(model_config, "input_segments", ["mt", "src", "ref"]))
+        self.requires_reference = bool(getattr(model_config, "requires_reference", True))
+        max_pos = model_config.encoder.n_positions
+        self.max_length = min(max_pos - 2, 512)
+        self.max_positions = min(max_pos, 512)
+        self.pad_idx = src_vocab.lookup_token(pad_token)
+        self.bos_id = src_vocab.lookup_token(bos_token)
+        self.eos_id = src_vocab.lookup_token(eos_token)
+
+        layer = getattr(model_config, "layer", "last")
+        layerwise_attention = None
+        if layer == "mix":
+            layerwise_attention = LayerwiseAttention(
+                num_layers=model_config.encoder.layers + 1,
+                layer_transformation=getattr(model_config, "layer_transformation", "softmax"),
+                layer_norm=bool(getattr(model_config, "layer_norm", False)),
+            )
+        self.representation = RepresentationExtractor(
+            layer=layer,
+            pool=getattr(model_config, "pool", "avg"),
+            layerwise_attention=layerwise_attention,
+        )
+
+        self.estimator = FeedForward(
+            in_dim=self._estimator_in_dim(),
+            hidden_sizes=getattr(model_config, "hidden_sizes", [3072, 1024]),
+            activations=getattr(model_config, "activations", "Tanh"),
+            final_activation=getattr(model_config, "final_activation", None),
+            dropout=float(getattr(model_config, "dropout", 0.1)),
+        )
+
+    @classmethod
+    def build_blocks(cls, model_config, vocabs, running_config=None, checkpoint_dims=None, device=None):
+        pad_token = vocabs["specials"]["pad_token"]
+        checkpoint_dims = checkpoint_dims or {}
+        vocab_size = checkpoint_dims.get("vocab_size", len(vocabs["src"]))
+        n_positions = checkpoint_dims.get("n_positions", model_config.embeddings.n_positions)
+        src_emb = RobertaEmbeddings(
+            word_vec_size=model_config.embeddings.src_word_vec_size,
+            word_vocab_size=vocab_size,
+            word_padding_idx=vocabs["src"].lookup_token(pad_token),
+            dropout=float(getattr(model_config, "dropout", 0.1)),
+            n_positions=n_positions,
+            token_type_vocab_size=max(1, getattr(model_config.embeddings, "token_type_vocab_size", 1)),
+            embedding_layer_norm=bool(getattr(model_config.embeddings, "embedding_layer_norm", False)),
+            norm_eps=model_config.norm_eps,
+        )
+        encoder = build_encoder(model_config, running_config=running_config)
+        return cls(model_config=model_config, encoder=encoder, src_emb=src_emb, device=device, vocabs=vocabs)
+
+    @staticmethod
+    def _inspect_checkpoint_dims(model_dir):
+        shard_path = os.path.join(model_dir, "model.00.safetensors")
+        state_dict = load_file(shard_path, device="cpu")
+        word_emb = state_dict["encoder.embeddings.word_embeddings.weight"]
+        pos_emb = state_dict["encoder.embeddings.position_embeddings.weight"]
+        return {
+            "vocab_size": int(word_emb.shape[0]),
+            "n_positions": int(pos_emb.shape[0]),
+        }
+
+    @classmethod
+    def from_model_dir(cls, model_dir, device=None):
+        model, _, _ = cls.for_inference(model_path=model_dir, device=device)
+        return model
+
+    @classmethod
+    def for_inference(cls, running_config=None, device_id=0, model_path=None, device=None):
+        model_dir = model_path or running_config.model_path[0]
+        metadata = get_metadata(model_dir)
+        model_config = metadata["config"].model
+        if model_config.architecture != "transformer_encoder_scorer":
+            raise ValueError(
+                f"Expected a transformer_encoder_scorer model, got architecture={model_config.architecture}"
+            )
+        vocabs = dict_to_vocabs(metadata["vocab"])
+        checkpoint_dims = cls._inspect_checkpoint_dims(model_dir)
+        if device is not None:
+            resolved_device = torch.device(device)
+        elif isinstance(device_id, (str, torch.device)):
+            resolved_device = torch.device(device_id)
+        else:
+            resolved_device = get_device(device_id=device_id)
+        model = cls.build_blocks(
+            model_config,
+            vocabs,
+            running_config=None,
+            checkpoint_dims=checkpoint_dims,
+            device=resolved_device,
+        )
+        keyfound = model.load_safe_state_dict(
+            model_dir,
+            running_config=running_config,
+            vocabs=vocabs,
+            metadata=metadata,
+            device=resolved_device,
+            strict=True,
+        )
+        model._validate_strict_checkpoint_load(keyfound)
+        model.to(model.device)
+        model.eval()
+        return model, vocabs, model.model_config
+
+    def _estimator_in_dim(self):
+        if self.scoring_type == "pooled_regression":
+            return self.hidden_size
+        if self.class_identifier == "unified_metric":
+            return self.hidden_size
+        if self.requires_reference:
+            return self.hidden_size * 6
+        return self.hidden_size * 4
+
+    def _checkpoint_key_for_param(self, full_name):
+        if full_name.startswith("src_emb."):
+            return "encoder.embeddings." + full_name[len("src_emb.") :]
+        if full_name.startswith("representation.layerwise_attention."):
+            return "layerwise_attention." + full_name[len("representation.layerwise_attention.") :]
+        return full_name
+
+    def _validate_strict_checkpoint_load(self, keyfound):
+        expected = {self._checkpoint_key_for_param(key) for key in self.state_dict()}
+        loaded = set(keyfound)
+        checkpoint_keys = set(getattr(self, "_last_loaded_checkpoint_keys", set()))
+        missing = sorted(expected - loaded)
+        extra = sorted(checkpoint_keys - loaded)
+        if missing or extra:
+            pieces = []
+            if missing:
+                pieces.append("missing keys: " + ", ".join(missing[:10]))
+            if extra:
+                pieces.append("extra keys: " + ", ".join(extra[:10]))
+            raise RuntimeError("Strict checkpoint load failed for EncoderScoringModel (" + "; ".join(pieces) + ")")
+
+    def _encode_ids_batch(self, ids_batch):
+        lengths = [len(ids) for ids in ids_batch]
+        max_len = max(lengths) if lengths else 0
+        padded = []
+        masks = []
+        for ids in ids_batch:
+            pad_len = max_len - len(ids)
+            padded.append(ids + [self.pad_idx] * pad_len)
+            masks.append([1] * len(ids) + [0] * pad_len)
+        return {
+            "input_ids": torch.tensor(padded, dtype=torch.long, device=self.device),
+            "attention_mask": torch.tensor(masks, dtype=torch.long, device=self.device),
+        }
+
+    def _hidden_states_from_ids(self, ids_batch):
+        encoded = self._encode_ids_batch(ids_batch)
+        emb = self.src_emb(encoded["input_ids"])
+        pad_mask = encoded["input_ids"].eq(self.pad_idx).unsqueeze(1)
+        layer = getattr(self.model_config, "layer", "last")
+        need_hidden_states = layer != "last"
+        if need_hidden_states:
+            _, _, hidden_states = self.encoder(emb, pad_mask=pad_mask, return_hidden_states=True)
+        else:
+            enc_out, _ = self.encoder(emb, pad_mask=pad_mask)
+            hidden_states = [enc_out]
+        return hidden_states, encoded["attention_mask"]
+
+    def _sentence_embed_from_ids(self, ids_batch):
+        hidden_states, attention_mask = self._hidden_states_from_ids(ids_batch)
+        return self.representation(hidden_states, attention_mask)
+
+    def _concat_segments_from_ids(self, segments):
+        batch = []
+        for items in zip(*segments):
+            new_sequence = items[0]
+            for seq in items[1:]:
+                new_sequence = [
+                    self.bos_id,
+                    *new_sequence[1:-1],
+                    self.eos_id,
+                    self.eos_id,
+                    *seq[1:-1],
+                    self.eos_id,
+                ]
+            if len(new_sequence) > self.max_positions:
+                new_sequence = new_sequence[: self.max_positions]
+            batch.append(new_sequence)
+        return batch
+
+    def _unified_forward_score_from_ids(self, ids_batch):
+        hidden_states, attention_mask = self._hidden_states_from_ids(ids_batch)
+        if self.representation.layerwise_attention is not None:
+            embeddings = self.representation.layerwise_attention(hidden_states, attention_mask)
+        elif self.representation.layer == "last":
+            embeddings = hidden_states[-1]
+        else:
+            embeddings = hidden_states[int(self.representation.layer)]
+        sentemb = embeddings[:, 0, :]
+        return self.estimator(sentemb).view(-1)
+
+    @torch.inference_mode()
+    def predict_scores(self, rows):
+        if not rows:
+            return torch.tensor([])
+        if self.scoring_type == "pooled_regression":
+            segment_name = self.input_segments[0] if self.input_segments else "mt"
+            segment_key = {"mt": "mt_ids", "src": "src_ids", "ref": "ref_ids"}.get(segment_name)
+            if segment_key is None:
+                raise ValueError(f"Unsupported pooled_regression input segment: {segment_name}")
+            if any(segment_key not in r for r in rows):
+                raise ValueError(f"pooled_regression requires {segment_name!r} segment ids")
+            seg = [r[segment_key] for r in rows]
+            rep = self._sentence_embed_from_ids(seg)
+            return self.estimator(rep).view(-1).detach().cpu()
+
+        if self.class_identifier == "unified_metric":
+            mt = [r["mt_ids"] for r in rows]
+            src = [r.get("src_ids", [self.bos_id, self.eos_id]) for r in rows]
+            ref = [r.get("ref_ids", [self.bos_id, self.eos_id]) for r in rows]
+            segments_by_name = {"mt": mt, "src": src, "ref": ref}
+            if self.input_segments == ["mt", "src", "ref"]:
+                candidate_segments = [["mt", "src"], ["mt", "ref"], ["mt", "src", "ref"]]
+                all_scores = []
+                for segment_names in candidate_segments:
+                    ordered = [segments_by_name[name] for name in segment_names]
+                    all_scores.append(self._unified_forward_score_from_ids(self._concat_segments_from_ids(ordered)))
+                scores = torch.stack(all_scores, dim=0).mean(dim=0)
+            else:
+                ordered = [segments_by_name[name] for name in self.input_segments if name in segments_by_name]
+                scores = self._unified_forward_score_from_ids(self._concat_segments_from_ids(ordered))
+            return scores.detach().cpu()
+
+        src_sentemb = self._sentence_embed_from_ids([r["src_ids"] for r in rows])
+        mt_sentemb = self._sentence_embed_from_ids([r["mt_ids"] for r in rows])
+        if self.requires_reference:
+            ref_sentemb = self._sentence_embed_from_ids([r["ref_ids"] for r in rows])
+            diff_ref = torch.abs(mt_sentemb - ref_sentemb)
+            diff_src = torch.abs(mt_sentemb - src_sentemb)
+            prod_ref = mt_sentemb * ref_sentemb
+            prod_src = mt_sentemb * src_sentemb
+            features = torch.cat((mt_sentemb, ref_sentemb, prod_ref, diff_ref, prod_src, diff_src), dim=1)
+        else:
+            diff_src = torch.abs(mt_sentemb - src_sentemb)
+            prod_src = mt_sentemb * src_sentemb
+            features = torch.cat((mt_sentemb, src_sentemb, prod_src, diff_src), dim=1)
+        return self.estimator(features).view(-1).detach().cpu()
 
 
 class VisionEncoderDecoderModel(BaseModel):
@@ -1315,6 +1595,8 @@ class AudioEncoderDecoderModel(BaseModel):
 
 def get_model_class(model_config):
     # might have more cases later
+    if getattr(model_config, "architecture", None) == "transformer_encoder_scorer":
+        return EncoderScoringModel
     if model_config.decoder is None:
         return EncoderModel
     elif model_config.encoder is None:

--- a/eole/models/model.py
+++ b/eole/models/model.py
@@ -71,10 +71,11 @@ def build_decoder(model_config, running_config=None):
 def build_src_emb(model_config, vocabs, running_config=None):
     # Build embeddings.
     pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
+    src_pad_idx = vocabs["src"][pad_token]
     if getattr(model_config.embeddings, "embedding_type", "standard") == "roberta":
         src_emb = RobertaEmbeddings(
             word_vec_size=model_config.embeddings.src_word_vec_size,
-            word_padding_idx=vocabs["tgt"][pad_token],
+            word_padding_idx=src_pad_idx,
             word_vocab_size=len(vocabs["src"]),
             dropout=getattr(running_config, "dropout", [0.0])[0],
             n_positions=model_config.embeddings.n_positions,
@@ -88,7 +89,7 @@ def build_src_emb(model_config, vocabs, running_config=None):
             position_encoding_type=model_config.embeddings.position_encoding_type,
             position_shift=model_config.embeddings.position_shift,
             dropout=getattr(running_config, "dropout", [0.0])[0],
-            word_padding_idx=vocabs["tgt"][pad_token],
+            word_padding_idx=src_pad_idx,
             word_vocab_size=len(vocabs["src"]),
             sparse=getattr(running_config, "optim", None) == "sparseadam",
             freeze_word_vecs=model_config.embeddings.freeze_word_vecs_enc,
@@ -1039,6 +1040,14 @@ class EncoderScoringModel(BaseModel):
         self.class_identifier = getattr(model_config, "class_identifier", "regression_metric")
         self.input_segments = list(getattr(model_config, "input_segments", ["mt", "src", "ref"]))
         self.requires_reference = bool(getattr(model_config, "requires_reference", True))
+        self.word_layer = getattr(model_config, "word_layer", None)
+        self.error_labels = list(getattr(model_config, "error_labels", ["minor", "major", "critical"]))
+        self.ids_to_error_label = {0: "O"}
+        for idx, label in enumerate(self.error_labels, start=1):
+            self.ids_to_error_label[idx] = f"I-{label}"
+        self.input_weights_spans = list(getattr(model_config, "input_weights_spans", [0.1667, 0.3333, 0.5]))
+        self.score_weights = list(getattr(model_config, "score_weights", [0.12, 0.33, 0.33, 0.22]))
+        self.decoding_threshold = getattr(model_config, "decoding_threshold", None)
         max_pos = model_config.encoder.n_positions
         self.max_length = min(max_pos - 2, 512)
         self.max_positions = min(max_pos, 512)
@@ -1067,6 +1076,8 @@ class EncoderScoringModel(BaseModel):
             final_activation=getattr(model_config, "final_activation", None),
             dropout=float(getattr(model_config, "dropout", 0.1)),
         )
+        if self.class_identifier == "xcomet_metric":
+            self.hidden2tag = nn.Linear(self.hidden_size, len(self.ids_to_error_label))
 
     @classmethod
     def build_blocks(cls, model_config, vocabs, running_config=None, checkpoint_dims=None, device=None):
@@ -1143,7 +1154,7 @@ class EncoderScoringModel(BaseModel):
     def _estimator_in_dim(self):
         if self.scoring_type == "pooled_regression":
             return self.hidden_size
-        if self.class_identifier == "unified_metric":
+        if self.class_identifier in {"unified_metric", "xcomet_metric"}:
             return self.hidden_size
         if self.requires_reference:
             return self.hidden_size * 6
@@ -1184,12 +1195,24 @@ class EncoderScoringModel(BaseModel):
             "attention_mask": torch.tensor(masks, dtype=torch.long, device=self.device),
         }
 
+    def _tokens_from_ids(self, token_ids):
+        vocab = self.vocabs["src"]
+        tokens = []
+        for token_id in token_ids:
+            if token_id in {self.bos_id, self.eos_id, self.pad_idx}:
+                continue
+            if hasattr(vocab, "lookup_index"):
+                tokens.append(vocab.lookup_index(int(token_id)))
+            else:
+                tokens.append(str(int(token_id)))
+        return "".join(token.replace("▁", " ") for token in tokens).strip()
+
     def _hidden_states_from_ids(self, ids_batch):
         encoded = self._encode_ids_batch(ids_batch)
         emb = self.src_emb(encoded["input_ids"])
         pad_mask = encoded["input_ids"].eq(self.pad_idx).unsqueeze(1)
         layer = getattr(self.model_config, "layer", "last")
-        need_hidden_states = layer != "last"
+        need_hidden_states = layer != "last" or self.class_identifier == "xcomet_metric"
         if need_hidden_states:
             _, _, hidden_states = self.encoder(emb, pad_mask=pad_mask, return_hidden_states=True)
         else:
@@ -1219,16 +1242,162 @@ class EncoderScoringModel(BaseModel):
             batch.append(new_sequence)
         return batch
 
-    def _unified_forward_score_from_ids(self, ids_batch):
+    def _unified_forward_from_ids(self, ids_batch):
         hidden_states, attention_mask = self._hidden_states_from_ids(ids_batch)
-        if self.representation.layerwise_attention is not None:
-            embeddings = self.representation.layerwise_attention(hidden_states, attention_mask)
-        elif self.representation.layer == "last":
-            embeddings = hidden_states[-1]
-        else:
-            embeddings = hidden_states[int(self.representation.layer)]
+        embeddings = self.representation.token_embeddings(hidden_states, attention_mask)
         sentemb = embeddings[:, 0, :]
-        return self.estimator(sentemb).view(-1)
+        score = self.estimator(sentemb).view(-1)
+        if self.class_identifier != "xcomet_metric":
+            return {"score": score}
+        word_layer = self.word_layer if self.word_layer is not None else len(hidden_states) - 1
+        if word_layer < 0 or word_layer >= len(hidden_states):
+            raise ValueError(f"Invalid xCOMET word_layer={word_layer}; model returned {len(hidden_states)} layers")
+        return {"score": score, "logits": self.hidden2tag(hidden_states[word_layer])}
+
+    def _unified_forward_score_from_ids(self, ids_batch):
+        return self._unified_forward_from_ids(ids_batch)["score"]
+
+    @staticmethod
+    def _xcomet_seq_len(rows, logits_seq_len):
+        return max(min(len(row["mt_ids"]), logits_seq_len) for row in rows)
+
+    def _xcomet_span_text(self, span, mt_text, decode_ids):
+        if decode_ids is not None:
+            return decode_ids(span["tokens"])
+        if mt_text is not None:
+            return mt_text[span["offset"][0] : span["offset"][1]]
+        return self._tokens_from_ids(span["tokens"])
+
+    def _decode_xcomet_spans(self, subword_probs, input_ids, mt_offsets, mt_texts=None, decode_token_ids=None):
+        decoded = []
+        if mt_texts is None:
+            mt_texts = [None] * len(mt_offsets)
+        if decode_token_ids is None:
+            decode_token_ids = [None] * len(mt_offsets)
+        for sentence_ids, sentence_probs, sentence_offsets, mt_text, decode_ids in zip(
+            input_ids, subword_probs, mt_offsets, mt_texts, decode_token_ids
+        ):
+            error_spans = []
+            in_span = False
+            span = {}
+            for token_id, probs, token_offset in zip(
+                sentence_ids[: len(sentence_offsets)], sentence_probs, sentence_offsets
+            ):
+                if self.decoding_threshold is not None:
+                    if torch.sum(probs[1:]) > self.decoding_threshold:
+                        probability, label_value = torch.topk(probs[1:], 1)
+                        label_value += 1
+                    else:
+                        probability, label_value = torch.topk(probs[:1], 1)
+                else:
+                    probability, label_value = torch.topk(probs, 1)
+                label_value = label_value.item() if label_value.dim() < 1 else label_value[0].item()
+                label = self.ids_to_error_label.get(label_value, "O")
+                if label.startswith("I") and not in_span:
+                    in_span = True
+                    span = {
+                        "tokens": [int(token_id.item())],
+                        "severity": label.split("-", 1)[1],
+                        "offset": list(token_offset),
+                        "confidence": [probability.reshape(1)],
+                    }
+                elif label.startswith("I") and in_span:
+                    span["tokens"].append(int(token_id.item()))
+                    span["confidence"].append(probability.reshape(1))
+                    span["offset"][1] = token_offset[1]
+                elif label == "O" and in_span:
+                    error_spans.append(span)
+                    in_span = False
+                    span = {}
+            # Match Unbabel COMET: spans are emitted only when closed by an O label.
+            # A trailing open span at truncation/EOS is intentionally dropped.
+            decoded.append(
+                [
+                    {
+                        "text": self._xcomet_span_text(span, mt_text, decode_ids),
+                        "confidence": torch.cat(span["confidence"]).mean().item(),
+                        "severity": span["severity"],
+                        "start": int(span["offset"][0]),
+                        "end": int(span["offset"][1]),
+                    }
+                    for span in error_spans
+                ]
+            )
+        return decoded
+
+    def _xcomet_mqm_scores(self, error_spans):
+        scores = []
+        for sentence_spans in error_spans:
+            penalty = 0
+            for annotation in sentence_spans:
+                if annotation["severity"] == "minor":
+                    penalty += 1
+                elif annotation["severity"] == "major":
+                    penalty += 5
+                elif annotation["severity"] == "critical":
+                    penalty += 10
+            scores.append((25 - min(penalty, 25)) / 25)
+        return torch.tensor(scores, dtype=torch.float32, device=getattr(self, "device", torch.device("cpu")))
+
+    @torch.inference_mode()
+    def predict_xcomet(self, rows):
+        if not rows:
+            return {"scores": [], "metadata": {"error_spans": []}}
+        if self.class_identifier != "xcomet_metric":
+            raise ValueError("predict_xcomet requires class_identifier='xcomet_metric'.")
+        mt = [r["mt_ids"] for r in rows]
+        src = [r.get("src_ids", [self.bos_id, self.eos_id]) for r in rows]
+        ref = [r.get("ref_ids", [self.bos_id, self.eos_id]) for r in rows]
+        segments_by_name = {"mt": mt, "src": src, "ref": ref}
+        has_ref = all("ref_ids" in r for r in rows)
+        if self.input_segments == ["mt", "src", "ref"] and has_ref:
+            candidate_segments = [["mt", "src"], ["mt", "ref"], ["mt", "src", "ref"]]
+            outputs = [
+                self._unified_forward_from_ids(
+                    self._concat_segments_from_ids([segments_by_name[name] for name in segment_names])
+                )
+                for segment_names in candidate_segments
+            ]
+            regression_scores = torch.stack(
+                [torch.where(o["score"] > 1.0, 1.0, o["score"]) * w for o, w in zip(outputs, self.score_weights[:3])],
+                dim=0,
+            ).sum(dim=0)
+            seq_len = self._xcomet_seq_len(rows, outputs[0]["logits"].shape[1])
+            span_probs = [
+                nn.functional.softmax(o["logits"], dim=2)[:, :seq_len, :] * w
+                for o, w in zip(outputs, self.input_weights_spans)
+            ]
+            subword_probs = torch.sum(torch.stack(span_probs), dim=0)
+            metadata = {
+                "src_scores": outputs[0]["score"].detach().cpu().tolist(),
+                "ref_scores": outputs[1]["score"].detach().cpu().tolist(),
+                "unified_scores": outputs[2]["score"].detach().cpu().tolist(),
+            }
+        else:
+            available_segments = {"mt", "src"}
+            if has_ref:
+                available_segments.add("ref")
+            ordered = [segments_by_name[name] for name in self.input_segments if name in available_segments]
+            outputs = [self._unified_forward_from_ids(self._concat_segments_from_ids(ordered))]
+            regression_score = torch.where(outputs[0]["score"] > 1.0, 1.0, outputs[0]["score"])
+            regression_scores = regression_score * sum(self.score_weights[:3])
+            seq_len = self._xcomet_seq_len(rows, outputs[0]["logits"].shape[1])
+            subword_probs = nn.functional.softmax(outputs[0]["logits"], dim=2)[:, :seq_len, :]
+            metadata = {"src_scores": regression_score.detach().cpu().tolist()}
+
+        default_offsets = [[(0, 0)] * seq_len for _ in rows]
+        mt_offsets = [r.get("mt_offsets", default_offsets[i])[:seq_len] for i, r in enumerate(rows)]
+        mt_texts = [r.get("mt_text") for r in rows]
+        decode_token_ids = [r.get("decode_token_ids") for r in rows]
+        mt_input_ids = self._encode_ids_batch(mt)["input_ids"][:, :seq_len]
+        error_spans = self._decode_xcomet_spans(
+            subword_probs, mt_input_ids, mt_offsets, mt_texts=mt_texts, decode_token_ids=decode_token_ids
+        )
+        mqm_scores = self._xcomet_mqm_scores(error_spans)
+        final_scores = regression_scores + mqm_scores.to(regression_scores.device) * self.score_weights[3]
+        metadata["mqm_scores"] = mqm_scores.detach().cpu().tolist()
+        metadata["error_spans"] = error_spans
+        return {"scores": final_scores.detach().cpu().tolist(), "metadata": metadata}
 
     @torch.inference_mode()
     def predict_scores(self, rows):
@@ -1244,6 +1413,9 @@ class EncoderScoringModel(BaseModel):
             seg = [r[segment_key] for r in rows]
             rep = self._sentence_embed_from_ids(seg)
             return self.estimator(rep).view(-1).detach().cpu()
+
+        if self.class_identifier == "xcomet_metric":
+            return torch.tensor(self.predict_xcomet(rows)["scores"], dtype=torch.float32)
 
         if self.class_identifier == "unified_metric":
             mt = [r["mt_ids"] for r in rows]

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -198,6 +198,7 @@ class Embeddings(nn.Module):
 
     def update_dropout(self, dropout):
         self.dropout.p = dropout
+        self.dropout_p = dropout
 
 
 class RobertaEmbeddings(nn.Module):
@@ -247,6 +248,7 @@ class RobertaEmbeddings(nn.Module):
 
     def update_dropout(self, dropout):
         self.dropout.p = dropout
+        self.dropout_p = dropout
 
 
 # Some utilitary functions for pretrained embeddings

--- a/eole/modules/embeddings.py
+++ b/eole/modules/embeddings.py
@@ -200,6 +200,55 @@ class Embeddings(nn.Module):
         self.dropout.p = dropout
 
 
+class RobertaEmbeddings(nn.Module):
+    def __init__(
+        self,
+        word_vec_size,
+        word_vocab_size,
+        word_padding_idx,
+        dropout=0.0,
+        n_positions=514,
+        token_type_vocab_size=1,
+        embedding_layer_norm=True,
+        norm_eps=1e-5,
+    ):
+        super().__init__()
+        self.word_padding_idx = word_padding_idx
+        self.word_embeddings = skip_init(
+            nn.Embedding,
+            num_embeddings=word_vocab_size,
+            embedding_dim=word_vec_size,
+            padding_idx=word_padding_idx,
+        )
+        self.position_embeddings = nn.Embedding(n_positions, word_vec_size, padding_idx=word_padding_idx)
+        self.token_type_embeddings = nn.Embedding(token_type_vocab_size, word_vec_size)
+        self.layer_norm = nn.LayerNorm(word_vec_size, eps=norm_eps) if embedding_layer_norm else None
+        self.dropout = nn.Dropout(p=dropout)
+        self.dropout_p = dropout
+
+    def _create_position_ids(self, input_ids):
+        # Fairseq/RoBERTa-style: positions start at padding_idx + 1
+        mask = input_ids.ne(self.word_padding_idx).int()
+        incremental_indices = torch.cumsum(mask, dim=1).type_as(mask) * mask
+        return incremental_indices.long() + self.word_padding_idx
+
+    def forward(self, input_ids, token_type_ids=None):
+        if token_type_ids is None:
+            token_type_ids = torch.zeros_like(input_ids)
+        position_ids = self._create_position_ids(input_ids)
+        emb = self.word_embeddings(input_ids)
+        emb = emb + self.position_embeddings(position_ids)
+        emb = emb + self.token_type_embeddings(token_type_ids)
+        if self.layer_norm is not None:
+            emb = self.layer_norm(emb)
+        if self.dropout_p > 0:
+            emb = self.dropout(emb)
+        return emb
+
+    def update_dropout(self, dropout):
+        self.dropout.p = dropout
+
+
 # Some utilitary functions for pretrained embeddings
 
 

--- a/eole/modules/estimator.py
+++ b/eole/modules/estimator.py
@@ -63,9 +63,9 @@ class FeedForward(nn.Module):
         self.ff = nn.Sequential(*modules)
 
     def forward(self, in_features: torch.Tensor) -> torch.Tensor:
-        ff_dtypes = {param.dtype for param in self.ff.parameters()}
-        if ff_dtypes == {torch.float16} and in_features.dtype != torch.float16:
-            in_features = in_features.to(torch.float16)
+        param = next(self.ff.parameters(), None)
+        if param is not None and param.dtype.is_floating_point and in_features.dtype != param.dtype:
+            in_features = in_features.to(param.dtype)
         return self.ff(in_features)
 
     @staticmethod

--- a/eole/modules/estimator.py
+++ b/eole/modules/estimator.py
@@ -48,12 +48,12 @@ class FeedForward(nn.Module):
         super().__init__()
         modules = []
         modules.append(nn.Linear(in_dim, hidden_sizes[0]))
-        modules.append(nn.GELU())
+        modules.append(self.build_activation(activations))
         modules.append(nn.Dropout(dropout))
 
         for i in range(1, len(hidden_sizes)):
             modules.append(nn.Linear(hidden_sizes[i - 1], hidden_sizes[i]))
-            modules.append(nn.GELU())
+            modules.append(self.build_activation(activations))
             modules.append(nn.Dropout(dropout))
 
         modules.append(nn.Linear(hidden_sizes[-1], int(out_dim)))
@@ -63,4 +63,18 @@ class FeedForward(nn.Module):
         self.ff = nn.Sequential(*modules)
 
     def forward(self, in_features: torch.Tensor) -> torch.Tensor:
+        ff_dtypes = {param.dtype for param in self.ff.parameters()}
+        if ff_dtypes == {torch.float16} and in_features.dtype != torch.float16:
+            in_features = in_features.to(torch.float16)
         return self.ff(in_features)
+
+    @staticmethod
+    def build_activation(name: str) -> nn.Module:
+        if name.lower() == "gelu":
+            return nn.GELU()
+        if hasattr(nn, name):
+            return getattr(nn, name)()
+        title_name = name.title()
+        if hasattr(nn, title_name):
+            return getattr(nn, title_name)()
+        raise ValueError(f"Invalid activation {name}")

--- a/eole/modules/representation.py
+++ b/eole/modules/representation.py
@@ -52,14 +52,15 @@ class RepresentationExtractor(nn.Module):
         self.pool = pool
         self.layerwise_attention = layerwise_attention
 
-    def forward(self, hidden_states, attention_mask):
+    def token_embeddings(self, hidden_states, attention_mask):
         if self.layerwise_attention is not None:
-            tok_emb = self.layerwise_attention(hidden_states, attention_mask)
-        elif self.layer == "last":
-            tok_emb = hidden_states[-1]
-        else:
-            tok_emb = hidden_states[int(self.layer)]
+            return self.layerwise_attention(hidden_states, attention_mask)
+        if self.layer == "last":
+            return hidden_states[-1]
+        return hidden_states[int(self.layer)]
 
+    def forward(self, hidden_states, attention_mask):
+        tok_emb = self.token_embeddings(hidden_states, attention_mask)
         if self.pool == "cls":
             return tok_emb[:, 0, :]
         if self.pool == "max":

--- a/eole/modules/representation.py
+++ b/eole/modules/representation.py
@@ -1,0 +1,71 @@
+import torch
+import torch.nn as nn
+
+
+class LayerwiseAttention(nn.Module):
+    def __init__(self, num_layers, layer_transformation="softmax", layer_norm=False):
+        super().__init__()
+        self.transform_fn = torch.softmax
+        self.layer_norm = layer_norm
+        if layer_transformation == "sparsemax":
+            from entmax import sparsemax
+
+            self.transform_fn = sparsemax
+        self.scalar_parameters = nn.ParameterList(
+            [nn.Parameter(torch.FloatTensor([0.0]), requires_grad=True) for _ in range(num_layers)]
+        )
+        self.gamma = nn.Parameter(torch.FloatTensor([1.0]), requires_grad=True)
+
+    def forward(self, tensors, mask=None):
+        weights = torch.cat([parameter for parameter in self.scalar_parameters])
+        normed_weights = self.transform_fn(weights, dim=0)
+        chunks = torch.split(normed_weights, 1)
+        if not self.layer_norm:
+            return self.gamma * sum(w * t for w, t in zip(chunks, tensors))
+
+        if mask is None:
+            raise ValueError("mask is required when layer_norm=True for layerwise attention")
+
+        def _layer_norm(tensor, broadcast_mask, mask_float):
+            tensor_masked = tensor * broadcast_mask
+            batch_size, _, input_dim = tensor.size()
+            num_elements_not_masked = mask_float.sum(1) * input_dim
+            mean = tensor_masked.view(batch_size, -1).sum(1)
+            mean = (mean / num_elements_not_masked).view(batch_size, 1, 1)
+            variance = (((tensor_masked - mean) * broadcast_mask) ** 2).view(batch_size, -1).sum(1)
+            variance = variance / num_elements_not_masked
+            normalized = (tensor - mean) / torch.sqrt(variance + 1e-12).view(batch_size, 1, 1)
+            return normalized
+
+        mask_float = mask.float()
+        broadcast_mask = mask_float.unsqueeze(-1)
+        pieces = []
+        for weight, tensor in zip(chunks, tensors):
+            pieces.append(weight * _layer_norm(tensor, broadcast_mask, mask_float))
+        return self.gamma * sum(pieces)
+
+
+class RepresentationExtractor(nn.Module):
+    def __init__(self, layer="last", pool="avg", layerwise_attention=None):
+        super().__init__()
+        self.layer = layer
+        self.pool = pool
+        self.layerwise_attention = layerwise_attention
+
+    def forward(self, hidden_states, attention_mask):
+        if self.layerwise_attention is not None:
+            tok_emb = self.layerwise_attention(hidden_states, attention_mask)
+        elif self.layer == "last":
+            tok_emb = hidden_states[-1]
+        else:
+            tok_emb = hidden_states[int(self.layer)]
+
+        if self.pool == "cls":
+            return tok_emb[:, 0, :]
+        if self.pool == "max":
+            mask = attention_mask.unsqueeze(-1).bool()
+            return tok_emb.masked_fill(~mask, float("-inf")).max(dim=1).values
+        mask = attention_mask.unsqueeze(-1)
+        sent = (tok_emb * mask).sum(dim=1)
+        denom = mask.sum(dim=1).clamp(min=1)
+        return sent / denom

--- a/eole/predict/__init__.py
+++ b/eole/predict/__init__.py
@@ -15,7 +15,10 @@ from eole import EOLE_TORCH_COMPILE
 
 
 def get_infer_class(model_config):
-    # might have more cases later
+    if getattr(model_config, "architecture", None) == "transformer_encoder_scorer":
+        from eole.predict.encoder_scorer import EncoderScorer
+
+        return EncoderScorer
     if model_config.decoder is None:
         return Encoder
     elif model_config.encoder is None:

--- a/eole/predict/encoder_scorer.py
+++ b/eole/predict/encoder_scorer.py
@@ -217,4 +217,13 @@ class EncoderScorer(Inference):
             elapsed = time.time() - t0
             logger.info("Scored %d pairs in %.1fs (%.0f seg/s)", len(rows), elapsed, len(rows) / max(elapsed, 1e-6))
 
+        score_level = getattr(self.config, "score_level", "segment")
+        if score_level == "system":
+            system_scores = [sum(all_scores) / len(all_scores)] if all_scores else []
+            if self.report_time:
+                logger.info("Emitted 1 system score")
+            return [[]], [system_scores], [[]]
+
+        if self.report_time:
+            logger.info("Emitted %d segment score%s", len(all_scores), "" if len(all_scores) == 1 else "s")
         return [[]], [all_scores], [[]]

--- a/eole/predict/encoder_scorer.py
+++ b/eole/predict/encoder_scorer.py
@@ -154,7 +154,9 @@ class EncoderScorer(Inference):
         if len(src_lines) != len(tgt_lines):
             raise ValueError(f"src and tgt line counts differ: {len(src_lines)} vs {len(tgt_lines)}")
         if ref_lines is not None and len(ref_lines) != len(tgt_lines):
-            raise ValueError(f"src/tgt/ref line counts differ: {len(src_lines)} vs {len(tgt_lines)} vs {len(ref_lines)}")
+            raise ValueError(
+                f"src/tgt/ref line counts differ: {len(src_lines)} vs {len(tgt_lines)} vs {len(ref_lines)}"
+            )
         if bool(getattr(self.model, "requires_reference", False)):
             if ref_lines is None:
                 raise ValueError(
@@ -181,7 +183,9 @@ class EncoderScorer(Inference):
                     "      tgt_subword_model: <path>\n"
                     f"(scoring_type={scoring_type!r} has no auto-fallback.)"
                 )
-        rows = build_segment_rows(tgt_lines, src_lines, ref_lines, tokenizer, self.model, encode_texts_fn=encode_texts_fn)
+        rows = build_segment_rows(
+            tgt_lines, src_lines, ref_lines, tokenizer, self.model, encode_texts_fn=encode_texts_fn
+        )
 
         batch_size = max(1, int(getattr(self.config, "batch_size", 64)))
         t0 = time.time()

--- a/eole/predict/encoder_scorer.py
+++ b/eole/predict/encoder_scorer.py
@@ -11,7 +11,11 @@ from types import SimpleNamespace
 import torch
 
 from eole.predict.inference import Inference
-from eole.utils.comet_scorer import build_comet_sentencepiece_transform, encode_comet_texts_to_ids
+from eole.utils.comet_scorer import (
+    build_comet_sentencepiece_transform,
+    encode_comet_texts_to_ids,
+    encode_comet_texts_to_ids_and_offsets,
+)
 from eole.utils.encoder_scorer import (
     build_segment_rows,
     predict_scores_with_oom_retry,
@@ -171,7 +175,10 @@ class EncoderScorer(Inference):
                 # COMET checkpoints bundle sentencepiece.bpe.model next to config.json,
                 # so we can construct the transform directly from the model dir.
                 tokenizer = build_comet_sentencepiece_transform(self.model, self.config.model_path[0])
-                encode_texts_fn = encode_comet_texts_to_ids
+                if getattr(self.model, "class_identifier", None) == "xcomet_metric":
+                    encode_texts_fn = encode_comet_texts_to_ids_and_offsets
+                else:
+                    encode_texts_fn = encode_comet_texts_to_ids
             else:
                 raise ValueError(
                     "EncoderScorer could not resolve a tokenizer transform. "

--- a/eole/predict/encoder_scorer.py
+++ b/eole/predict/encoder_scorer.py
@@ -1,0 +1,209 @@
+"""Predictor that scores parallel (src, tgt) pairs with an EncoderScoringModel.
+
+Plugs into InferenceEnginePY in place of Translator/Encoder/etc when the loaded
+model has architecture="transformer_encoder_scorer". Reads --src and --tgt files,
+tokenizes both sides via the recipe's `sentencepiece` transform, and writes one
+score per line to --output.
+"""
+
+import time
+from types import SimpleNamespace
+import torch
+
+from eole.predict.inference import Inference
+from eole.utils.comet_scorer import build_comet_sentencepiece_transform, encode_comet_texts_to_ids
+from eole.utils.encoder_scorer import (
+    build_segment_rows,
+    predict_scores_with_oom_retry,
+)
+from eole.utils.logging import logger as _module_logger
+
+logger = _module_logger
+
+
+def _read_lines(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.rstrip("\n") for line in f]
+
+
+def _resolve_sentencepiece(transforms):
+    if isinstance(transforms, dict) and "sentencepiece" in transforms:
+        return transforms["sentencepiece"]
+    if hasattr(transforms, "transforms"):
+        for t in transforms.transforms:
+            if hasattr(t, "tokenize_string"):
+                return t
+    if hasattr(transforms, "__iter__") and not isinstance(transforms, dict):
+        for t in transforms:
+            if hasattr(t, "tokenize_string"):
+                return t
+    return None
+
+
+def _encode_texts_with_tokenizer(texts, tokenizer, model):
+    bos_id = model.bos_id
+    eos_id = model.eos_id
+    max_length = model.max_length
+    vocab = model.vocabs["src"]
+    encoded = []
+    for text in texts:
+        pieces = tokenizer.tokenize_string(text, side="src", is_train=False)
+        ids = [vocab.lookup_token(piece) for piece in pieces]
+        encoded.append(([bos_id] + ids + [eos_id])[:max_length])
+    return encoded
+
+
+class EncoderScorer(Inference):
+    def __init__(
+        self,
+        model,
+        vocabs,
+        config,
+        model_config,
+        device_id=0,
+        global_scorer=None,
+        report_score=True,
+        logger=None,  # noqa: A002 — kept for engine API compat; module-level `logger` is used
+        return_gold_log_probs=False,
+    ):
+        defaults = {
+            "transforms": [],
+            "optional_eos": [],
+            "dynamic_shapes": None,
+            "n_best": 1,
+            "max_length": 0,
+            "max_length_ratio": 0,
+            "context_length": 0,
+            "beam_size": 1,
+            "temperature": 1.0,
+            "top_k": 0,
+            "top_p": 0.0,
+            "min_length": 0,
+            "ban_unk_token": False,
+            "ratio": 0.0,
+            "stepwise_penalty": False,
+            "dump_beam": "",
+            "block_ngram_repeat": 0,
+            "ignore_when_blocking": [],
+            "replace_unk": False,
+            "tgt_file_prefix": False,
+            "phrase_table": "",
+            "data_type": "text",
+            "verbose": False,
+            "report_time": bool(getattr(config, "report_time", False)),
+            "report_align": False,
+            "gold_align": False,
+            "seed": -1,
+            "with_score": bool(getattr(config, "with_score", False)),
+            "estim_only": True,
+            "self_attn_backend": "pytorch",
+            "fuse_kvq": False,
+            "fuse_gate": False,
+        }
+        for key, value in defaults.items():
+            if not hasattr(config, key):
+                setattr(config, key, value)
+        if not hasattr(model_config, "add_estimator"):
+            setattr(model_config, "add_estimator", True)
+        if not hasattr(model_config, "estimator_type"):
+            setattr(model_config, "estimator_type", "first_token")
+        if global_scorer is None:
+            global_scorer = SimpleNamespace(has_cov_pen=False)
+
+        super().__init__(
+            model,
+            vocabs,
+            config,
+            model_config,
+            device_id=device_id,
+            global_scorer=global_scorer,
+            report_score=report_score,
+            logger=logger,
+            return_gold_log_probs=return_gold_log_probs,
+        )
+        self.config = config
+
+        compute_dtype = getattr(config, "compute_dtype", None)
+        if compute_dtype in (torch.float16, torch.bfloat16):
+            self.model.to(compute_dtype)
+        param_dtype = None
+        if hasattr(self.model, "parameters"):
+            try:
+                param_dtype = next(iter(self.model.parameters())).dtype
+            except (StopIteration, TypeError):
+                pass
+        _module_logger.info(
+            "EncoderScorer: batch_size=%s, compute_dtype=%s, model.dtype=%s",
+            getattr(config, "batch_size", None),
+            compute_dtype,
+            param_dtype,
+        )
+
+    def update_settings(self, **kwargs):
+        return
+
+    def _predict(self, infer_iter, transforms, attn_debug, align_debug, streamer=None):
+        if not self.config.src or not self.config.tgt:
+            raise ValueError("EncoderScorer requires both --src and --tgt files.")
+        if not getattr(self.config, "with_score", False):
+            raise ValueError("EncoderScorer requires --with_score to emit estimator scores.")
+
+        src_lines = _read_lines(self.config.src)
+        tgt_lines = _read_lines(self.config.tgt)
+        ref_lines = _read_lines(self.config.ref) if getattr(self.config, "ref", None) else None
+        if len(src_lines) != len(tgt_lines):
+            raise ValueError(f"src and tgt line counts differ: {len(src_lines)} vs {len(tgt_lines)}")
+        if ref_lines is not None and len(ref_lines) != len(tgt_lines):
+            raise ValueError(f"src/tgt/ref line counts differ: {len(src_lines)} vs {len(tgt_lines)} vs {len(ref_lines)}")
+        if bool(getattr(self.model, "requires_reference", False)):
+            if ref_lines is None:
+                raise ValueError(
+                    "This EncoderScorer model requires references. Provide --ref (with --tgt as hypothesis/mt)."
+                )
+
+        tokenizer = _resolve_sentencepiece(transforms)
+        encode_texts_fn = _encode_texts_with_tokenizer if tokenizer is not None else None
+        if tokenizer is None:
+            scoring_type = getattr(self.model, "scoring_type", None)
+            if scoring_type == "comet":
+                # COMET checkpoints bundle sentencepiece.bpe.model next to config.json,
+                # so we can construct the transform directly from the model dir.
+                tokenizer = build_comet_sentencepiece_transform(self.model, self.config.model_path[0])
+                encode_texts_fn = encode_comet_texts_to_ids
+            else:
+                raise ValueError(
+                    "EncoderScorer could not resolve a tokenizer transform. "
+                    "Declare one in the recipe, e.g.:\n"
+                    "  transforms: [sentencepiece]\n"
+                    "  transforms_configs:\n"
+                    "    sentencepiece:\n"
+                    "      src_subword_model: <path>\n"
+                    "      tgt_subword_model: <path>\n"
+                    f"(scoring_type={scoring_type!r} has no auto-fallback.)"
+                )
+        rows = build_segment_rows(tgt_lines, src_lines, ref_lines, tokenizer, self.model, encode_texts_fn=encode_texts_fn)
+
+        batch_size = max(1, int(getattr(self.config, "batch_size", 64)))
+        t0 = time.time()
+        last_logged = 0
+
+        def _log_progress(i):
+            nonlocal last_logged
+            if self.report_time and i - last_logged >= 10000:
+                elapsed = time.time() - t0
+                logger.info("Scored %d/%d (%.0f seg/s)", i, len(rows), i / max(elapsed, 1e-6))
+                last_logged = i
+
+        all_scores = predict_scores_with_oom_retry(
+            self.model,
+            rows,
+            batch_size,
+            logger=logger,
+            progress_callback=_log_progress,
+        )
+
+        if self.report_time:
+            elapsed = time.time() - t0
+            logger.info("Scored %d pairs in %.1fs (%.0f seg/s)", len(rows), elapsed, len(rows) / max(elapsed, 1e-6))
+
+        return [[]], [all_scores], [[]]

--- a/eole/predict/generator.py
+++ b/eole/predict/generator.py
@@ -208,7 +208,8 @@ class GeneratorLM(Inference):
         if not self.estim_only:
             # (5) Begin decoding step by step:
             if self.report_time:
-                torch.cuda.synchronize()
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
                 beg_time = time()
 
             for step in range(decode_strategy.max_length):
@@ -244,7 +245,8 @@ class GeneratorLM(Inference):
                     self.model.decoder.map_state(lambda state: state[decode_strategy.select_indices])
 
                 if self.report_time and step == 0:
-                    torch.cuda.synchronize()
+                    if torch.cuda.is_available():
+                        torch.cuda.synchronize()
                     self.step0_time.append(time() - beg_time)
 
                 self.model.decoder._extend_cache()  # noop when dynamic_shape is False

--- a/eole/predict/translator.py
+++ b/eole/predict/translator.py
@@ -172,7 +172,8 @@ class Translator(Inference):
 
         # (1) Run the encoder on the src.
         if self.report_time:
-            torch.cuda.synchronize()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
             beg_time = time()
         src, enc_final_hs, enc_out, src_len = self._run_encoder(batch)
         self.model.decoder.init_state(enc_out=enc_out, enc_final_hs=enc_final_hs)
@@ -205,7 +206,8 @@ class Translator(Inference):
             raise TypeError("enc_out must be either a tensor or a tuple of tensors")
 
         if self.report_time:
-            torch.cuda.synchronize()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
             self.step0_time.append(time() - beg_time)
 
         # (4) warmup for Torch compile

--- a/eole/scorers/eole_comet.py
+++ b/eole/scorers/eole_comet.py
@@ -38,6 +38,7 @@ def _resolve_model_dir(model_name):
 class _EoleCometBase(Scorer):
     uses_gpu = True
     default_model = None
+    metric_name = "EOLE-COMET"
     expect_reference = True
     expected_class_identifier = None
 
@@ -47,19 +48,21 @@ class _EoleCometBase(Scorer):
 
     def _validate_family(self, model):
         if getattr(model, "scoring_type", "comet") != "comet":
-            raise ValueError("EOLE-COMET requires a transformer_encoder_scorer model with scoring_type='comet'.")
+            raise ValueError(
+                f"{self.metric_name} requires a transformer_encoder_scorer model with scoring_type='comet'."
+            )
         if (
             self.expected_class_identifier is not None
             and getattr(model, "class_identifier", None) != self.expected_class_identifier
         ):
             raise ValueError(
-                f"{self.__class__.__name__} expects a converted model with "
+                f"{self.metric_name} expects a converted model with "
                 f"class_identifier='{self.expected_class_identifier}'."
             )
         if self.expect_reference and not model.requires_reference:
-            raise ValueError("EOLE-COMET expects a reference-based converted model.")
+            raise ValueError(f"{self.metric_name} expects a reference-based converted model.")
         if not self.expect_reference and model.requires_reference:
-            raise ValueError("EOLE-COMET-KIWI expects a reference-free converted model.")
+            raise ValueError(f"{self.metric_name} expects a reference-free converted model.")
 
     def _build_sp_transform(self, model, model_dir):
         return build_comet_sentencepiece_transform(model, model_dir)
@@ -102,6 +105,7 @@ class _EoleCometBase(Scorer):
 @register_scorer(metric="EOLE-COMET")
 class EoleCometScorer(_EoleCometBase):
     default_model = "Unbabel/wmt22-comet-da"
+    metric_name = "EOLE-COMET"
     expect_reference = True
     expected_class_identifier = "regression_metric"
 
@@ -109,6 +113,7 @@ class EoleCometScorer(_EoleCometBase):
 @register_scorer(metric="EOLE-COMET-KIWI")
 class EoleCometKiwiScorer(_EoleCometBase):
     default_model = "Unbabel/wmt22-cometkiwi-da"
+    metric_name = "EOLE-COMET-KIWI"
     expect_reference = False
     expected_class_identifier = "referenceless_regression_metric"
 
@@ -116,5 +121,6 @@ class EoleCometKiwiScorer(_EoleCometBase):
 @register_scorer(metric="EOLE-XCOMET")
 class EoleXCometScorer(_EoleCometBase):
     default_model = "Unbabel/XCOMET-XL"
+    metric_name = "EOLE-XCOMET"
     expect_reference = True
     expected_class_identifier = "xcomet_metric"

--- a/eole/scorers/eole_comet.py
+++ b/eole/scorers/eole_comet.py
@@ -51,13 +51,13 @@ class _EoleCometBase(Scorer):
             raise ValueError(
                 f"{self.metric_name} requires a transformer_encoder_scorer model with scoring_type='comet'."
             )
-        if (
-            self.expected_class_identifier is not None
-            and getattr(model, "class_identifier", None) != self.expected_class_identifier
-        ):
+        expected = self.expected_class_identifier
+        if isinstance(expected, str):
+            expected = {expected}
+        if expected is not None and getattr(model, "class_identifier", None) not in expected:
+            expected_text = ", ".join(f"'{value}'" for value in sorted(expected))
             raise ValueError(
-                f"{self.metric_name} expects a converted model with "
-                f"class_identifier='{self.expected_class_identifier}'."
+                f"{self.metric_name} expects a converted model with " f"class_identifier in {{{expected_text}}}."
             )
         if self.expect_reference and not model.requires_reference:
             raise ValueError(f"{self.metric_name} expects a reference-based converted model.")
@@ -115,7 +115,7 @@ class EoleCometKiwiScorer(_EoleCometBase):
     default_model = "Unbabel/wmt22-cometkiwi-da"
     metric_name = "EOLE-COMET-KIWI"
     expect_reference = False
-    expected_class_identifier = "referenceless_regression_metric"
+    expected_class_identifier = {"referenceless_regression_metric", "unified_metric"}
 
 
 @register_scorer(metric="EOLE-XCOMET")

--- a/eole/scorers/eole_comet.py
+++ b/eole/scorers/eole_comet.py
@@ -1,0 +1,96 @@
+import os
+
+from .scorer import Scorer
+from eole.models.model import EncoderScoringModel
+from eole.scorers import register_scorer
+from eole.utils.comet_scorer import build_comet_sentencepiece_transform, encode_comet_texts_to_ids
+from eole.utils.encoder_scorer import (
+    build_segment_rows,
+    predict_scores_with_oom_retry,
+)
+from eole.utils.misc import clear_gpu_cache, get_device
+
+import torch
+
+
+def _slug(name):
+    return name.replace("/", "--")
+
+
+def _resolve_model_dir(model_name):
+    if model_name and os.path.isdir(model_name):
+        return model_name
+    model_root = os.environ.get("EOLE_MODEL_DIR")
+    if model_root and model_name:
+        candidate = os.path.join(model_root, "comet", _slug(model_name))
+        if os.path.isdir(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "EOLE converted COMET model not found. Convert first with: "
+        "`eole convert COMET --model <hf-model-id> --output <dir>` and set `comet_model` to that directory."
+    )
+
+
+class _EoleCometBase(Scorer):
+    uses_gpu = True
+    default_model = None
+    expect_reference = True
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model_name = getattr(config, "comet_model", None) or self.default_model
+
+    def _validate_family(self, model):
+        if getattr(model, "scoring_type", "comet") != "comet":
+            raise ValueError("EOLE-COMET requires a transformer_encoder_scorer model with scoring_type='comet'.")
+        if self.expect_reference and not model.requires_reference:
+            raise ValueError("EOLE-COMET expects a reference-based converted model.")
+        if not self.expect_reference and model.requires_reference:
+            raise ValueError("EOLE-COMET-KIWI expects a reference-free converted model.")
+
+    def _build_sp_transform(self, model, model_dir):
+        return build_comet_sentencepiece_transform(model, model_dir)
+
+    def _encode_texts(self, texts, tokenizer, model):
+        return encode_comet_texts_to_ids(texts, tokenizer, model)
+
+    def _resolve_device(self):
+        configured_device = getattr(self.config, "comet_device", None)
+        if configured_device:
+            return torch.device(configured_device)
+        return get_device()
+
+    def compute_score(self, preds, texts_refs, texts_srcs=None):
+        if not preds:
+            return 0
+        if texts_srcs is None:
+            texts_srcs = [""] * len(preds)
+
+        model_dir = _resolve_model_dir(self.model_name)
+        model = EncoderScoringModel.from_model_dir(model_dir, device=self._resolve_device())
+        self._validate_family(model)
+
+        if model.requires_reference and (texts_refs is None or len(texts_refs) != len(preds)):
+            raise ValueError("This EOLE-COMET model requires references, but they were missing or malformed.")
+
+        tokenizer = self._build_sp_transform(model, model_dir)
+        rows = build_segment_rows(preds, texts_srcs, texts_refs, tokenizer, model, encode_texts_fn=self._encode_texts)
+
+        batch_size = max(1, int(getattr(self.config, "comet_batch_size", 64)))
+        all_scores = predict_scores_with_oom_retry(model, rows, batch_size)
+
+        del model
+        clear_gpu_cache()
+        return float(sum(all_scores) / len(all_scores))
+
+
+@register_scorer(metric="EOLE-COMET")
+class EoleCometScorer(_EoleCometBase):
+    default_model = "Unbabel/wmt22-comet-da"
+    expect_reference = True
+
+
+@register_scorer(metric="EOLE-COMET-KIWI")
+class EoleCometKiwiScorer(_EoleCometBase):
+    default_model = "Unbabel/wmt22-cometkiwi-da"
+    expect_reference = False

--- a/eole/scorers/eole_comet.py
+++ b/eole/scorers/eole_comet.py
@@ -3,7 +3,11 @@ import os
 from .scorer import Scorer
 from eole.models.model import EncoderScoringModel
 from eole.scorers import register_scorer
-from eole.utils.comet_scorer import build_comet_sentencepiece_transform, encode_comet_texts_to_ids
+from eole.utils.comet_scorer import (
+    build_comet_sentencepiece_transform,
+    encode_comet_texts_to_ids,
+    encode_comet_texts_to_ids_and_offsets,
+)
 from eole.utils.encoder_scorer import (
     build_segment_rows,
     predict_scores_with_oom_retry,
@@ -35,6 +39,7 @@ class _EoleCometBase(Scorer):
     uses_gpu = True
     default_model = None
     expect_reference = True
+    expected_class_identifier = None
 
     def __init__(self, config):
         super().__init__(config)
@@ -43,6 +48,14 @@ class _EoleCometBase(Scorer):
     def _validate_family(self, model):
         if getattr(model, "scoring_type", "comet") != "comet":
             raise ValueError("EOLE-COMET requires a transformer_encoder_scorer model with scoring_type='comet'.")
+        if (
+            self.expected_class_identifier is not None
+            and getattr(model, "class_identifier", None) != self.expected_class_identifier
+        ):
+            raise ValueError(
+                f"{self.__class__.__name__} expects a converted model with "
+                f"class_identifier='{self.expected_class_identifier}'."
+            )
         if self.expect_reference and not model.requires_reference:
             raise ValueError("EOLE-COMET expects a reference-based converted model.")
         if not self.expect_reference and model.requires_reference:
@@ -52,6 +65,8 @@ class _EoleCometBase(Scorer):
         return build_comet_sentencepiece_transform(model, model_dir)
 
     def _encode_texts(self, texts, tokenizer, model):
+        if getattr(model, "class_identifier", None) == "xcomet_metric":
+            return encode_comet_texts_to_ids_and_offsets(texts, tokenizer, model)
         return encode_comet_texts_to_ids(texts, tokenizer, model)
 
     def _resolve_device(self):
@@ -88,9 +103,18 @@ class _EoleCometBase(Scorer):
 class EoleCometScorer(_EoleCometBase):
     default_model = "Unbabel/wmt22-comet-da"
     expect_reference = True
+    expected_class_identifier = "regression_metric"
 
 
 @register_scorer(metric="EOLE-COMET-KIWI")
 class EoleCometKiwiScorer(_EoleCometBase):
     default_model = "Unbabel/wmt22-cometkiwi-da"
     expect_reference = False
+    expected_class_identifier = "referenceless_regression_metric"
+
+
+@register_scorer(metric="EOLE-XCOMET")
+class EoleXCometScorer(_EoleCometBase):
+    default_model = "Unbabel/XCOMET-XL"
+    expect_reference = True
+    expected_class_identifier = "xcomet_metric"

--- a/eole/tests/test_embeddings.py
+++ b/eole/tests/test_embeddings.py
@@ -1,5 +1,5 @@
 import unittest
-from eole.modules.embeddings import Embeddings
+from eole.modules.embeddings import Embeddings, RobertaEmbeddings
 from eole.constants import PositionEncodingType
 
 import itertools
@@ -119,3 +119,31 @@ class TestEmbeddings(unittest.TestCase):
                         trainable_params[param_name].ne(old_weights[param_name]).any(),
                         param_name + " " + init_case.__str__(),
                     )
+
+    def test_embeddings_update_dropout_syncs_cached_probability(self):
+        emb = Embeddings(
+            word_vec_size=4,
+            word_vocab_size=8,
+            word_padding_idx=0,
+            position_encoding_type=None,
+            dropout=0.0,
+        )
+
+        emb.update_dropout(0.2)
+
+        self.assertEqual(emb.dropout.p, 0.2)
+        self.assertEqual(emb.dropout_p, 0.2)
+
+    def test_roberta_embeddings_update_dropout_syncs_cached_probability(self):
+        emb = RobertaEmbeddings(
+            word_vec_size=4,
+            word_vocab_size=8,
+            word_padding_idx=0,
+            dropout=0.0,
+            n_positions=8,
+        )
+
+        emb.update_dropout(0.2)
+
+        self.assertEqual(emb.dropout.p, 0.2)
+        self.assertEqual(emb.dropout_p, 0.2)

--- a/eole/tests/test_encoder_scorer.py
+++ b/eole/tests/test_encoder_scorer.py
@@ -1,0 +1,356 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from eole.predict.encoder_scorer import EncoderScorer, _resolve_sentencepiece
+from eole.models.model import EncoderScoringModel
+from eole.utils.encoder_scorer import build_segment_rows
+
+
+class FakeTokenizer:
+    def tokenize_string(self, text, side="src", is_train=False):
+        return text.strip().split()
+
+
+class FakeVocab:
+    def lookup_token(self, piece):
+        return 2 if piece else 0
+
+    def __len__(self):
+        return 10
+
+
+class FakeModel:
+    def __init__(self, scores, raises_oom_until=None):
+        src_vocab = FakeVocab()
+        self.bos_id = 0
+        self.eos_id = 1
+        self.max_length = 64
+        self.vocabs = {
+            "src": src_vocab,
+            "tgt": src_vocab,
+            "specials": {"bos_token": "<s>", "eos_token": "</s>", "pad_token": "<pad>", "unk_token": "<unk>"},
+            "decoder_start_token": "<s>",
+        }
+        self._scores = list(scores)
+        self._raises_oom_until = raises_oom_until or 0
+        self._oom_calls = 0
+        self._offset = 0
+        self.calls = []
+        self.requires_reference = False
+        self.input_segments = []
+
+    def predict_scores(self, rows):
+        self.calls.append(len(rows))
+        if self._oom_calls < self._raises_oom_until:
+            self._oom_calls += 1
+            raise torch.cuda.OutOfMemoryError("simulated OOM")
+        n = len(rows)
+        out = torch.tensor(self._scores[self._offset : self._offset + n], dtype=torch.float32)
+        self._offset += n
+        return out
+
+
+def _write(path, lines):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def _encode_texts_for_test(texts, tokenizer, model):
+    return [[model.bos_id, *[2 for _ in tokenizer.tokenize_string(text)], model.eos_id] for text in texts]
+
+
+class TestEncoderScorer(unittest.TestCase):
+    def test_resolves_sentencepiece_from_dict(self):
+        tx = FakeTokenizer()
+        self.assertIs(_resolve_sentencepiece({"sentencepiece": tx, "filtertoolong": object()}), tx)
+
+    def test_resolves_sentencepiece_from_iterable(self):
+        tx = FakeTokenizer()
+        self.assertIs(_resolve_sentencepiece([object(), tx]), tx)
+
+    def test_resolves_sentencepiece_missing_returns_none(self):
+        self.assertIsNone(_resolve_sentencepiece([object()]))
+        self.assertIsNone(_resolve_sentencepiece({"filtertoolong": object()}))
+
+    def test_predict_writes_one_score_per_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["hello world", "foo bar baz", "x"])
+            _write(tgt_path, ["bonjour monde", "qux quux quuux", "y"])
+            model = FakeModel(scores=[0.1, 0.5, 0.9])
+            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            scores_out, estims_out, preds_out = scorer._predict(
+                infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+            )
+            self.assertEqual(scores_out, [[]])
+            self.assertEqual(preds_out, [[]])
+            self.assertEqual(len(estims_out[0]), 3)
+            self.assertAlmostEqual(estims_out[0][0], 0.1, places=6)
+            self.assertAlmostEqual(estims_out[0][2], 0.9, places=6)
+
+    def test_oom_fallback_halves_batch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a"] * 8)
+            _write(tgt_path, ["b"] * 8)
+            model = FakeModel(scores=[0.1] * 8, raises_oom_until=1)
+            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=8, report_time=False, with_score=True)
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            scorer._predict(
+                infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+            )
+            # First call raises OOM at batch=8, then halves to 4 → 4 → 4 (succeeds at half)
+            self.assertEqual(model.calls, [8, 4, 4])
+
+    def test_fallback_only_for_comet_scoring_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a"])
+            _write(tgt_path, ["b"])
+            model = FakeModel(scores=[0.1])
+            model.scoring_type = "pooled_regression"
+            config = SimpleNamespace(
+                src=src_path,
+                tgt=tgt_path,
+                output=out_path,
+                batch_size=2,
+                report_time=False,
+                model_path=[tmp],
+                with_score=True,
+            )
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            with self.assertRaisesRegex(ValueError, "scoring_type='pooled_regression'"):
+                scorer._predict(infer_iter=None, transforms={}, attn_debug=False, align_debug=False)
+
+    def test_mismatched_lengths_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a", "b"])
+            _write(tgt_path, ["c"])
+            model = FakeModel(scores=[0.1])
+            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            with self.assertRaises(ValueError):
+                scorer._predict(
+                    infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+                )
+
+    def test_reference_model_requires_ref_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a"])
+            _write(tgt_path, ["b"])
+            model = FakeModel(scores=[0.1])
+            model.requires_reference = True
+            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            with self.assertRaisesRegex(ValueError, "Provide --ref"):
+                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+
+    def test_reference_model_with_ref_scores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            ref_path = os.path.join(tmp, "ref.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a", "b"])
+            _write(tgt_path, ["c", "d"])
+            _write(ref_path, ["e", "f"])
+            model = FakeModel(scores=[0.1, 0.2])
+            model.requires_reference = True
+            config = SimpleNamespace(
+                src=src_path,
+                tgt=tgt_path,
+                ref=ref_path,
+                output=out_path,
+                batch_size=2,
+                report_time=False,
+                with_score=True,
+            )
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            scores_out, estims_out, preds_out = scorer._predict(
+                infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+            )
+            self.assertEqual(scores_out, [[]])
+            self.assertEqual(preds_out, [[]])
+            self.assertEqual(len(estims_out[0]), 2)
+
+    def test_reference_model_ref_length_mismatch_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            ref_path = os.path.join(tmp, "ref.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a", "b"])
+            _write(tgt_path, ["c", "d"])
+            _write(ref_path, ["e"])
+            model = FakeModel(scores=[0.1, 0.2])
+            model.requires_reference = True
+            config = SimpleNamespace(
+                src=src_path,
+                tgt=tgt_path,
+                ref=ref_path,
+                output=out_path,
+                batch_size=2,
+                report_time=False,
+                with_score=True,
+            )
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            with self.assertRaisesRegex(ValueError, "src/tgt/ref line counts differ"):
+                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+
+    def test_build_segment_rows_includes_ref_for_ref_input_segment(self):
+        model = FakeModel(scores=[0.1])
+        model.input_segments = ["ref"]
+
+        rows = build_segment_rows(["mt"], ["src"], ["ref"], FakeTokenizer(), model, _encode_texts_for_test)
+
+        self.assertIn("ref_ids", rows[0])
+
+    def test_pooled_regression_uses_configured_segment_ids(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.scoring_type = "pooled_regression"
+        model.input_segments = ["mt"]
+        model._sentence_embed_from_ids = lambda seg: torch.tensor([[float(len(ids))] for ids in seg])
+        model.estimator = lambda rep: rep
+
+        scores = model.predict_scores([{"src_ids": [0], "mt_ids": [0, 2, 1]}, {"src_ids": [0], "mt_ids": [0, 2, 2, 1]}])
+
+        self.assertEqual(scores.tolist(), [3.0, 4.0])
+
+    def test_pooled_regression_errors_when_configured_segment_missing(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.scoring_type = "pooled_regression"
+        model.input_segments = ["ref"]
+
+        with self.assertRaisesRegex(ValueError, "requires 'ref' segment ids"):
+            model.predict_scores([{"src_ids": [0], "mt_ids": [0, 2, 1]}])
+
+    def test_checkpoint_key_mapping_for_converted_comet_weights(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+
+        self.assertEqual(
+            model._checkpoint_key_for_param("src_emb.word_embeddings.weight"),
+            "encoder.embeddings.word_embeddings.weight",
+        )
+        self.assertEqual(
+            model._checkpoint_key_for_param("representation.layerwise_attention.scalar_parameters.0"),
+            "layerwise_attention.scalar_parameters.0",
+        )
+        self.assertEqual(model._checkpoint_key_for_param("encoder.transformer_layers.0.weight"), "encoder.transformer_layers.0.weight")
+
+    def test_strict_checkpoint_validation_raises_on_missing_or_extra_keys(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.state_dict = lambda: {
+            "src_emb.word_embeddings.weight": torch.empty(1),
+            "encoder.transformer_layers.0.weight": torch.empty(1),
+        }
+        model._last_loaded_checkpoint_keys = {
+            "encoder.embeddings.word_embeddings.weight",
+            "unexpected.weight",
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "missing keys: encoder.transformer_layers.0.weight; extra keys: unexpected.weight"):
+            model._validate_strict_checkpoint_load({"encoder.embeddings.word_embeddings.weight": True})
+
+    def test_strict_checkpoint_validation_accepts_complete_remapped_load(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.state_dict = lambda: {
+            "src_emb.word_embeddings.weight": torch.empty(1),
+            "representation.layerwise_attention.gamma": torch.empty(1),
+        }
+        model._last_loaded_checkpoint_keys = {
+            "encoder.embeddings.word_embeddings.weight",
+            "layerwise_attention.gamma",
+        }
+
+        model._validate_strict_checkpoint_load(
+            {
+                "encoder.embeddings.word_embeddings.weight": True,
+                "layerwise_attention.gamma": True,
+            }
+        )
+
+
+class TestDtypePropagation(unittest.TestCase):
+    def _make_scorer(self, compute_dtype):
+        from unittest.mock import MagicMock
+
+        model = FakeModel(scores=[0.0])
+        # FakeModel has no parameters(); stub one so the startup log line works.
+        model.parameters = lambda: iter([torch.zeros(1, dtype=torch.float32)])
+        model.to = MagicMock()
+        config = SimpleNamespace(
+            src=None,
+            tgt=None,
+            output=None,
+            batch_size=512,
+            compute_dtype=compute_dtype,
+            report_time=False,
+            with_score=True,
+        )
+        scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+        return model, scorer
+
+    def test_requires_with_score(self):
+        model = FakeModel(scores=[0.1])
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a"])
+            _write(tgt_path, ["b"])
+            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False)
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            with self.assertRaisesRegex(ValueError, "--with_score"):
+                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+
+    def test_fp16_calls_model_to(self):
+        model, _ = self._make_scorer(torch.float16)
+        model.to.assert_called_once_with(torch.float16)
+
+    def test_bf16_calls_model_to(self):
+        model, _ = self._make_scorer(torch.bfloat16)
+        model.to.assert_called_once_with(torch.bfloat16)
+
+    def test_fp32_does_not_call_to(self):
+        model, _ = self._make_scorer(torch.float32)
+        model.to.assert_not_called()
+
+    def test_no_dtype_does_not_call_to(self):
+        model, _ = self._make_scorer(None)
+        model.to.assert_not_called()
+
+
+class TestDispatch(unittest.TestCase):
+    def test_get_infer_class_routes_scoring_architecture(self):
+        from eole.predict import get_infer_class
+        from eole.predict.encoder_scorer import EncoderScorer as Cls
+
+        cfg = SimpleNamespace(architecture="transformer_encoder_scorer", decoder=None, encoder=SimpleNamespace())
+        self.assertIs(get_infer_class(cfg), Cls)
+
+    def test_get_infer_class_legacy_encoder_unchanged(self):
+        from eole.predict import get_infer_class, Encoder
+
+        cfg = SimpleNamespace(architecture="transformer", decoder=None, encoder=SimpleNamespace(encoder_type="text"))
+        self.assertIs(get_infer_class(cfg), Encoder)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eole/tests/test_encoder_scorer.py
+++ b/eole/tests/test_encoder_scorer.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import torch
 
 from eole.predict.encoder_scorer import EncoderScorer, _resolve_sentencepiece
+from eole.inference_engine import InferenceEngine
 from eole.models.model import EncoderScoringModel
 from eole.config.models import TransformerEncoderScorerModelConfig
 from eole.modules.estimator import FeedForward
@@ -98,6 +99,43 @@ class TestEncoderScorer(unittest.TestCase):
             self.assertEqual(len(estims_out[0]), 3)
             self.assertAlmostEqual(estims_out[0][0], 0.1, places=6)
             self.assertAlmostEqual(estims_out[0][2], 0.9, places=6)
+
+    def test_predict_system_score_level_outputs_mean_score(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "src.txt")
+            tgt_path = os.path.join(tmp, "tgt.txt")
+            out_path = os.path.join(tmp, "scores.txt")
+            _write(src_path, ["a", "b", "c"])
+            _write(tgt_path, ["x", "y", "z"])
+            model = FakeModel(scores=[0.1, 0.5, 0.9])
+            config = SimpleNamespace(
+                src=src_path,
+                tgt=tgt_path,
+                output=out_path,
+                batch_size=2,
+                report_time=False,
+                with_score=True,
+                score_level="system",
+            )
+            scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
+            scores_out, estims_out, preds_out = scorer._predict(
+                infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+            )
+
+            self.assertEqual(scores_out, [[]])
+            self.assertEqual(preds_out, [[]])
+            self.assertEqual(len(estims_out[0]), 1)
+            self.assertAlmostEqual(estims_out[0][0], 0.5, places=6)
+
+    def test_system_score_level_writes_single_score_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = os.path.join(tmp, "scores.txt")
+            engine = InferenceEngine(SimpleNamespace(with_score=True))
+
+            engine._write_predictions_to_file([], [0.5], [], out_path)
+
+            with open(out_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), "0.5\n")
 
     def test_oom_fallback_halves_batch(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/eole/tests/test_encoder_scorer.py
+++ b/eole/tests/test_encoder_scorer.py
@@ -7,6 +7,8 @@ import torch
 
 from eole.predict.encoder_scorer import EncoderScorer, _resolve_sentencepiece
 from eole.models.model import EncoderScoringModel
+from eole.config.models import TransformerEncoderScorerModelConfig
+from eole.modules.estimator import FeedForward
 from eole.utils.encoder_scorer import build_segment_rows
 
 
@@ -234,6 +236,49 @@ class TestEncoderScorer(unittest.TestCase):
 
         self.assertIn("ref_ids", rows[0])
 
+    def test_build_segment_rows_rejects_src_length_mismatch(self):
+        model = FakeModel(scores=[0.1])
+
+        with self.assertRaisesRegex(ValueError, "texts_srcs"):
+            build_segment_rows(["mt", "mt2"], ["src"], None, FakeTokenizer(), model, _encode_texts_for_test)
+
+    def test_build_segment_rows_rejects_ref_length_mismatch(self):
+        model = FakeModel(scores=[0.1])
+
+        with self.assertRaisesRegex(ValueError, "texts_refs"):
+            build_segment_rows(["mt", "mt2"], ["src", "src2"], ["ref"], FakeTokenizer(), model, _encode_texts_for_test)
+
+    def test_xcomet_config_sets_reference_requirement_from_segments(self):
+        config = TransformerEncoderScorerModelConfig(
+            class_identifier="xcomet_metric",
+            requires_reference=False,
+            input_segments=["mt", "src", "ref"],
+        )
+
+        self.assertTrue(config.requires_reference)
+        self.assertEqual(config.error_labels, ["minor", "major", "critical"])
+
+    def test_xcomet_config_rejects_custom_error_labels(self):
+        with self.assertRaisesRegex(ValueError, "error_labels"):
+            TransformerEncoderScorerModelConfig(
+                class_identifier="xcomet_metric",
+                error_labels=["minor", "major"],
+            )
+
+    def test_xcomet_config_rejects_malformed_input_weights(self):
+        with self.assertRaisesRegex(ValueError, "input_weights_spans"):
+            TransformerEncoderScorerModelConfig(
+                class_identifier="xcomet_metric",
+                input_weights_spans=[1.0],
+            )
+
+    def test_xcomet_config_rejects_malformed_score_weights(self):
+        with self.assertRaisesRegex(ValueError, "score_weights"):
+            TransformerEncoderScorerModelConfig(
+                class_identifier="xcomet_metric",
+                score_weights=[0.33, 0.33, 0.34],
+            )
+
     def test_pooled_regression_uses_configured_segment_ids(self):
         model = EncoderScoringModel.__new__(EncoderScoringModel)
         model.scoring_type = "pooled_regression"
@@ -303,8 +348,97 @@ class TestEncoderScorer(unittest.TestCase):
             }
         )
 
+    def test_xcomet_mqm_scores_from_spans(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+
+        scores = model._xcomet_mqm_scores(
+            [
+                [{"severity": "minor"}, {"severity": "major"}],
+                [{"severity": "critical"}, {"severity": "critical"}, {"severity": "critical"}],
+            ]
+        )
+
+        self.assertAlmostEqual(scores.tolist()[0], 19 / 25, places=6)
+        self.assertEqual(scores.tolist()[1], 0.0)
+
+    def test_xcomet_decode_groups_error_spans(self):
+        vocab = FakeVocab()
+        vocab.lookup_index = lambda idx: {2: "▁bad", 3: "ly"}.get(idx, "")
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.bos_id = 0
+        model.eos_id = 1
+        model.pad_idx = 9
+        model.vocabs = {"src": vocab}
+        model.ids_to_error_label = {0: "O", 1: "I-minor", 2: "I-major", 3: "I-critical"}
+        model.decoding_threshold = None
+
+        probs = torch.tensor([[[0.9, 0.1, 0.0, 0.0], [0.1, 0.8, 0.1, 0.0], [0.1, 0.7, 0.2, 0.0], [0.8, 0.2, 0.0, 0.0]]])
+        spans = model._decode_xcomet_spans(probs, torch.tensor([[0, 2, 3, 1]]), [[(0, 0), (0, 3), (3, 5), (0, 0)]])
+
+        self.assertEqual(len(spans[0]), 1)
+        self.assertEqual(spans[0][0]["severity"], "minor")
+        self.assertEqual(spans[0][0]["start"], 0)
+        self.assertEqual(spans[0][0]["end"], 5)
+        self.assertEqual(spans[0][0]["text"], "badly")
+
+    def test_xcomet_decode_drops_unclosed_trailing_span_to_match_unbabel(self):
+        vocab = FakeVocab()
+        vocab.lookup_index = lambda idx: {2: "▁bad", 3: "ly"}.get(idx, "")
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.bos_id = 0
+        model.eos_id = 1
+        model.pad_idx = 9
+        model.vocabs = {"src": vocab}
+        model.ids_to_error_label = {0: "O", 1: "I-minor", 2: "I-major", 3: "I-critical"}
+        model.decoding_threshold = None
+
+        probs = torch.tensor([[[0.9, 0.1, 0.0, 0.0], [0.1, 0.8, 0.1, 0.0], [0.1, 0.7, 0.2, 0.0]]])
+        spans = model._decode_xcomet_spans(probs, torch.tensor([[0, 2, 3]]), [[(0, 0), (0, 3), (3, 5)]])
+
+        self.assertEqual(spans, [[]])
+
+    def test_xcomet_predict_combines_regression_and_spans(self):
+        model = EncoderScoringModel.__new__(EncoderScoringModel)
+        model.class_identifier = "xcomet_metric"
+        model.input_segments = ["mt", "src", "ref"]
+        model.score_weights = [0.12, 0.33, 0.33, 0.22]
+        model.input_weights_spans = [0.1667, 0.3333, 0.5]
+        model.bos_id = 0
+        model.eos_id = 1
+        model.pad_idx = 9
+        model.device = torch.device("cpu")
+        model.vocabs = {"src": FakeVocab()}
+        model._concat_segments_from_ids = lambda segments: segments[0]
+        model._encode_ids_batch = lambda ids: {"input_ids": torch.tensor([[0, 2, 1]])}
+        calls = []
+
+        def _fake_forward(ids):
+            calls.append(ids)
+            logits = torch.tensor([[[4.0, 0.0, 0.0, 0.0], [0.0, 4.0, 0.0, 0.0], [4.0, 0.0, 0.0, 0.0]]])
+            return {"score": torch.tensor([0.5]), "logits": logits}
+
+        model._unified_forward_from_ids = _fake_forward
+        model._decode_xcomet_spans = lambda probs, input_ids, offsets, **kwargs: [
+            [{"severity": "minor", "start": 0, "end": 3, "confidence": 1.0, "text": "bad"}]
+        ]
+
+        result = model.predict_xcomet(
+            [{"mt_ids": [0, 2, 1], "src_ids": [0, 2, 1], "ref_ids": [0, 2, 1], "mt_offsets": [(0, 0), (0, 3), (0, 0)]}]
+        )
+
+        self.assertEqual(len(calls), 3)
+        self.assertAlmostEqual(result["scores"][0], 0.5 * 0.78 + (24 / 25) * 0.22, places=6)
+        self.assertEqual(result["metadata"]["error_spans"][0][0]["severity"], "minor")
+
 
 class TestDtypePropagation(unittest.TestCase):
+    def test_feed_forward_casts_inputs_to_bfloat16_parameters(self):
+        feed_forward = FeedForward(in_dim=2, hidden_sizes=[4], out_dim=1).to(torch.bfloat16)
+
+        output = feed_forward(torch.ones(1, 2, dtype=torch.float32))
+
+        self.assertEqual(output.dtype, torch.bfloat16)
+
     def _make_scorer(self, compute_dtype):
         from unittest.mock import MagicMock
 

--- a/eole/tests/test_encoder_scorer.py
+++ b/eole/tests/test_encoder_scorer.py
@@ -84,7 +84,9 @@ class TestEncoderScorer(unittest.TestCase):
             _write(src_path, ["hello world", "foo bar baz", "x"])
             _write(tgt_path, ["bonjour monde", "qux quux quuux", "y"])
             model = FakeModel(scores=[0.1, 0.5, 0.9])
-            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            config = SimpleNamespace(
+                src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True
+            )
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             scores_out, estims_out, preds_out = scorer._predict(
                 infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
@@ -103,7 +105,9 @@ class TestEncoderScorer(unittest.TestCase):
             _write(src_path, ["a"] * 8)
             _write(tgt_path, ["b"] * 8)
             model = FakeModel(scores=[0.1] * 8, raises_oom_until=1)
-            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=8, report_time=False, with_score=True)
+            config = SimpleNamespace(
+                src=src_path, tgt=tgt_path, output=out_path, batch_size=8, report_time=False, with_score=True
+            )
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             scorer._predict(
                 infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
@@ -141,7 +145,9 @@ class TestEncoderScorer(unittest.TestCase):
             _write(src_path, ["a", "b"])
             _write(tgt_path, ["c"])
             model = FakeModel(scores=[0.1])
-            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            config = SimpleNamespace(
+                src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True
+            )
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             with self.assertRaises(ValueError):
                 scorer._predict(
@@ -157,10 +163,14 @@ class TestEncoderScorer(unittest.TestCase):
             _write(tgt_path, ["b"])
             model = FakeModel(scores=[0.1])
             model.requires_reference = True
-            config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True)
+            config = SimpleNamespace(
+                src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False, with_score=True
+            )
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             with self.assertRaisesRegex(ValueError, "Provide --ref"):
-                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+                scorer._predict(
+                    infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+                )
 
     def test_reference_model_with_ref_scores(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -212,7 +222,9 @@ class TestEncoderScorer(unittest.TestCase):
             )
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             with self.assertRaisesRegex(ValueError, "src/tgt/ref line counts differ"):
-                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+                scorer._predict(
+                    infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+                )
 
     def test_build_segment_rows_includes_ref_for_ref_input_segment(self):
         model = FakeModel(scores=[0.1])
@@ -252,7 +264,10 @@ class TestEncoderScorer(unittest.TestCase):
             model._checkpoint_key_for_param("representation.layerwise_attention.scalar_parameters.0"),
             "layerwise_attention.scalar_parameters.0",
         )
-        self.assertEqual(model._checkpoint_key_for_param("encoder.transformer_layers.0.weight"), "encoder.transformer_layers.0.weight")
+        self.assertEqual(
+            model._checkpoint_key_for_param("encoder.transformer_layers.0.weight"),
+            "encoder.transformer_layers.0.weight",
+        )
 
     def test_strict_checkpoint_validation_raises_on_missing_or_extra_keys(self):
         model = EncoderScoringModel.__new__(EncoderScoringModel)
@@ -265,7 +280,9 @@ class TestEncoderScorer(unittest.TestCase):
             "unexpected.weight",
         }
 
-        with self.assertRaisesRegex(RuntimeError, "missing keys: encoder.transformer_layers.0.weight; extra keys: unexpected.weight"):
+        with self.assertRaisesRegex(
+            RuntimeError, "missing keys: encoder.transformer_layers.0.weight; extra keys: unexpected.weight"
+        ):
             model._validate_strict_checkpoint_load({"encoder.embeddings.word_embeddings.weight": True})
 
     def test_strict_checkpoint_validation_accepts_complete_remapped_load(self):
@@ -318,7 +335,9 @@ class TestDtypePropagation(unittest.TestCase):
             config = SimpleNamespace(src=src_path, tgt=tgt_path, output=out_path, batch_size=2, report_time=False)
             scorer = EncoderScorer(model, model.vocabs, config, model_config=SimpleNamespace())
             with self.assertRaisesRegex(ValueError, "--with_score"):
-                scorer._predict(infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False)
+                scorer._predict(
+                    infer_iter=None, transforms={"sentencepiece": FakeTokenizer()}, attn_debug=False, align_debug=False
+                )
 
     def test_fp16_calls_model_to(self):
         model, _ = self._make_scorer(torch.float16)

--- a/eole/tests/test_eole_comet_scorer.py
+++ b/eole/tests/test_eole_comet_scorer.py
@@ -101,7 +101,7 @@ class TestEoleCometScorers(unittest.TestCase):
     def test_eole_comet_rejects_xcomet_model_family(self):
         fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2], class_identifier="xcomet_metric")
 
-        with self.assertRaisesRegex(ValueError, "class_identifier='regression_metric'"):
+        with self.assertRaisesRegex(ValueError, "class_identifier in .*'regression_metric'"):
             self._compute_score_with_runtime(EoleCometScorer, fake_runtime)
 
     def test_eole_comet_kiwi_accepts_referenceless_regression_model_family(self):
@@ -113,10 +113,17 @@ class TestEoleCometScorers(unittest.TestCase):
 
         self.assertAlmostEqual(score, 0.2, places=6)
 
+    def test_eole_comet_kiwi_accepts_unified_metric_model_family(self):
+        fake_runtime = FakeRuntime(requires_reference=False, scores=[0.2], class_identifier="unified_metric")
+
+        score = self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
+
+        self.assertAlmostEqual(score, 0.2, places=6)
+
     def test_eole_comet_kiwi_rejects_xcomet_model_family(self):
         fake_runtime = FakeRuntime(requires_reference=False, scores=[0.2], class_identifier="xcomet_metric")
 
-        with self.assertRaisesRegex(ValueError, "class_identifier='referenceless_regression_metric'"):
+        with self.assertRaisesRegex(ValueError, "class_identifier in .*'unified_metric'"):
             self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
 
     def test_eole_comet_kiwi_rejects_regular_comet_model_family(self):
@@ -126,7 +133,7 @@ class TestEoleCometScorers(unittest.TestCase):
             class_identifier="regression_metric",
         )
 
-        with self.assertRaisesRegex(ValueError, "class_identifier='referenceless_regression_metric'"):
+        with self.assertRaisesRegex(ValueError, "class_identifier in .*'unified_metric'"):
             self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
 
     def test_eole_comet_uses_configured_device(self):
@@ -176,7 +183,7 @@ class TestEoleCometScorers(unittest.TestCase):
             patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
             patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
         ):
-            with self.assertRaisesRegex(ValueError, "class_identifier='xcomet_metric'"):
+            with self.assertRaisesRegex(ValueError, "class_identifier in .*'xcomet_metric'"):
                 scorer.compute_score(["a"], ["r"], ["s"])
 
 

--- a/eole/tests/test_eole_comet_scorer.py
+++ b/eole/tests/test_eole_comet_scorer.py
@@ -1,0 +1,91 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer
+
+
+class FakeRuntime:
+    def __init__(self, requires_reference, scores):
+        self.requires_reference = requires_reference
+        self._scores = scores
+
+    def predict_scores(self, rows):
+        import torch
+
+        return torch.tensor(self._scores[: len(rows)], dtype=torch.float32)
+
+
+class TestEoleCometScorers(unittest.TestCase):
+    def test_eole_comet_requires_references(self):
+        scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=4))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.5, 0.6])
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+            patch.object(EoleCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(
+                EoleCometScorer, "_encode_texts", side_effect=[[[0, 1], [0, 1]], [[0, 1], [0, 1]], [[0, 1], [0, 1]]]
+            ),
+        ):
+            with self.assertRaises(ValueError):
+                scorer.compute_score(["a", "b"], None, ["s1", "s2"])
+
+    def test_eole_comet_kiwi_rejects_reference_model_family(self):
+        scorer = EoleCometKiwiScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=4))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.5])
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+            patch.object(EoleCometKiwiScorer, "_build_sp_transform", return_value=object()),
+            patch.object(EoleCometKiwiScorer, "_encode_texts", side_effect=[[[0, 1]], [[0, 1]]]),
+        ):
+            with self.assertRaises(ValueError):
+                scorer.compute_score(["a"], ["r"], ["s"])
+
+    def test_eole_comet_aggregation(self):
+        scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2, 0.4, 0.8])
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+            patch.object(EoleCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(
+                EoleCometScorer,
+                "_encode_texts",
+                side_effect=[[[0, 1], [0, 1], [0, 1]], [[0, 1], [0, 1], [0, 1]], [[0, 1], [0, 1], [0, 1]]],
+            ),
+        ):
+            score = scorer.compute_score(["a", "b", "c"], ["r1", "r2", "r3"], ["s1", "s2", "s3"])
+        self.assertAlmostEqual(score, (0.2 + 0.4 + 0.8) / 3, places=6)
+
+    def test_eole_comet_uses_configured_device(self):
+        scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8, comet_device="cpu"))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2])
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime) as load_mock,
+            patch.object(EoleCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(EoleCometScorer, "_encode_texts", side_effect=[[[0, 1]], [[0, 1]], [[0, 1]]]),
+        ):
+            scorer.compute_score(["a"], ["r"], ["s"])
+        load_mock.assert_called_once_with("dummy", device=torch.device("cpu"))
+
+    def test_eole_comet_auto_selects_mps(self):
+        scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2])
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.get_device", return_value=torch.device("mps")),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime) as load_mock,
+            patch.object(EoleCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(EoleCometScorer, "_encode_texts", side_effect=[[[0, 1]], [[0, 1]], [[0, 1]]]),
+        ):
+            scorer.compute_score(["a"], ["r"], ["s"])
+        load_mock.assert_called_once_with("dummy", device=torch.device("mps"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eole/tests/test_eole_comet_scorer.py
+++ b/eole/tests/test_eole_comet_scorer.py
@@ -4,13 +4,14 @@ from unittest.mock import patch
 
 import torch
 
-from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer
+from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer, EoleXCometScorer
 
 
 class FakeRuntime:
-    def __init__(self, requires_reference, scores):
+    def __init__(self, requires_reference, scores, class_identifier="regression_metric"):
         self.requires_reference = requires_reference
         self._scores = scores
+        self.class_identifier = class_identifier
 
     def predict_scores(self, rows):
         import torch
@@ -19,6 +20,23 @@ class FakeRuntime:
 
 
 class TestEoleCometScorers(unittest.TestCase):
+    def _compute_score_with_runtime(self, scorer_cls, runtime, preds=None, refs=None, srcs=None):
+        scorer = scorer_cls(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        preds = preds or ["a"]
+        refs = refs or ["r"]
+        srcs = srcs or ["s"]
+        encoded = [[0, 1] for _ in preds]
+        encode_calls = [encoded, encoded]
+        if runtime.requires_reference:
+            encode_calls.append(encoded)
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=runtime),
+            patch.object(scorer_cls, "_build_sp_transform", return_value=object()),
+            patch.object(scorer_cls, "_encode_texts", side_effect=encode_calls),
+        ):
+            return scorer.compute_score(preds, refs, srcs)
+
     def test_eole_comet_requires_references(self):
         scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=4))
         fake_runtime = FakeRuntime(requires_reference=True, scores=[0.5, 0.6])
@@ -61,6 +79,44 @@ class TestEoleCometScorers(unittest.TestCase):
             score = scorer.compute_score(["a", "b", "c"], ["r1", "r2", "r3"], ["s1", "s2", "s3"])
         self.assertAlmostEqual(score, (0.2 + 0.4 + 0.8) / 3, places=6)
 
+    def test_eole_comet_accepts_regression_model_family(self):
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2], class_identifier="regression_metric")
+
+        score = self._compute_score_with_runtime(EoleCometScorer, fake_runtime)
+
+        self.assertAlmostEqual(score, 0.2, places=6)
+
+    def test_eole_comet_rejects_xcomet_model_family(self):
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2], class_identifier="xcomet_metric")
+
+        with self.assertRaisesRegex(ValueError, "class_identifier='regression_metric'"):
+            self._compute_score_with_runtime(EoleCometScorer, fake_runtime)
+
+    def test_eole_comet_kiwi_accepts_referenceless_regression_model_family(self):
+        fake_runtime = FakeRuntime(
+            requires_reference=False, scores=[0.2], class_identifier="referenceless_regression_metric"
+        )
+
+        score = self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
+
+        self.assertAlmostEqual(score, 0.2, places=6)
+
+    def test_eole_comet_kiwi_rejects_xcomet_model_family(self):
+        fake_runtime = FakeRuntime(requires_reference=False, scores=[0.2], class_identifier="xcomet_metric")
+
+        with self.assertRaisesRegex(ValueError, "class_identifier='referenceless_regression_metric'"):
+            self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
+
+    def test_eole_comet_kiwi_rejects_regular_comet_model_family(self):
+        fake_runtime = FakeRuntime(
+            requires_reference=False,
+            scores=[0.2],
+            class_identifier="regression_metric",
+        )
+
+        with self.assertRaisesRegex(ValueError, "class_identifier='referenceless_regression_metric'"):
+            self._compute_score_with_runtime(EoleCometKiwiScorer, fake_runtime)
+
     def test_eole_comet_uses_configured_device(self):
         scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8, comet_device="cpu"))
         fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2])
@@ -85,6 +141,31 @@ class TestEoleCometScorers(unittest.TestCase):
         ):
             scorer.compute_score(["a"], ["r"], ["s"])
         load_mock.assert_called_once_with("dummy", device=torch.device("mps"))
+
+    def test_eole_xcomet_accepts_xcomet_model_family(self):
+        scorer = EoleXCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2, 0.6], class_identifier="xcomet_metric")
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+            patch.object(EoleXCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(
+                EoleXCometScorer, "_encode_texts", side_effect=[[[0, 1], [0, 1]], [[0, 1], [0, 1]], [[0, 1], [0, 1]]]
+            ),
+        ):
+            score = scorer.compute_score(["a", "b"], ["r1", "r2"], ["s1", "s2"])
+
+        self.assertAlmostEqual(score, 0.4, places=6)
+
+    def test_eole_xcomet_rejects_regular_comet_model_family(self):
+        scorer = EoleXCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        fake_runtime = FakeRuntime(requires_reference=True, scores=[0.2], class_identifier="regression_metric")
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+        ):
+            with self.assertRaisesRegex(ValueError, "class_identifier='xcomet_metric'"):
+                scorer.compute_score(["a"], ["r"], ["s"])
 
 
 if __name__ == "__main__":

--- a/eole/tests/test_eole_comet_scorer.py
+++ b/eole/tests/test_eole_comet_scorer.py
@@ -8,10 +8,11 @@ from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer, EoleXC
 
 
 class FakeRuntime:
-    def __init__(self, requires_reference, scores, class_identifier="regression_metric"):
+    def __init__(self, requires_reference, scores, class_identifier="regression_metric", scoring_type="comet"):
         self.requires_reference = requires_reference
         self._scores = scores
         self.class_identifier = class_identifier
+        self.scoring_type = scoring_type
 
     def predict_scores(self, rows):
         import torch
@@ -60,8 +61,19 @@ class TestEoleCometScorers(unittest.TestCase):
             patch.object(EoleCometKiwiScorer, "_build_sp_transform", return_value=object()),
             patch.object(EoleCometKiwiScorer, "_encode_texts", side_effect=[[[0, 1]], [[0, 1]]]),
         ):
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "EOLE-COMET-KIWI"):
                 scorer.compute_score(["a"], ["r"], ["s"])
+
+    def test_eole_xcomet_reports_metric_name_for_wrong_scoring_type(self):
+        fake_runtime = FakeRuntime(
+            requires_reference=True,
+            scores=[0.2],
+            class_identifier="xcomet_metric",
+            scoring_type="pooled_regression",
+        )
+
+        with self.assertRaisesRegex(ValueError, "EOLE-XCOMET"):
+            self._compute_score_with_runtime(EoleXCometScorer, fake_runtime)
 
     def test_eole_comet_aggregation(self):
         scorer = EoleCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))

--- a/eole/tests/test_models.py
+++ b/eole/tests/test_models.py
@@ -4,6 +4,7 @@ import torch
 import pyonmttok
 from eole.constants import DefaultTokens
 from collections import Counter
+from types import SimpleNamespace
 import eole
 import eole.inputters
 
@@ -22,6 +23,20 @@ class NoOpPosition:
 
     def update(self, *args, **kwargs):
         return None
+
+
+class FakeVocab:
+    def __init__(self, pad_idx, size=16):
+        self.pad_idx = pad_idx
+        self.size = size
+
+    def __getitem__(self, token):
+        if token == DefaultTokens.PAD:
+            return self.pad_idx
+        return 0
+
+    def __len__(self):
+        return self.size
 
 
 opt = TrainConfig(
@@ -104,6 +119,23 @@ class TestModel(unittest.TestCase):
             compare_to = torch.zeros(bsize, source_l, opt.model.embeddings.src_word_vec_size)
 
         self.assertEqual(res.size(), compare_to.size())
+
+    def test_build_src_emb_uses_source_vocab_padding_index(self):
+        vocabs = {
+            "src": FakeVocab(pad_idx=7, size=16),
+            "tgt": FakeVocab(pad_idx=3, size=16),
+            "specials": {"pad_token": DefaultTokens.PAD},
+        }
+        running_config = SimpleNamespace(dropout=[0.0], optim=None)
+        model_config = copy.deepcopy(self.opt.model)
+
+        standard_emb = build_src_emb(model_config, vocabs, running_config=running_config)
+        model_config.embeddings.embedding_type = "roberta"
+        model_config.embeddings.n_positions = 16
+        roberta_emb = build_src_emb(model_config, vocabs, running_config=running_config)
+
+        self.assertEqual(standard_emb.word_padding_idx, 7)
+        self.assertEqual(roberta_emb.word_padding_idx, 7)
 
     def encoder_forward(self, opt, source_l=3, bsize=1):
         """

--- a/eole/tests/test_predict_config_ref.py
+++ b/eole/tests/test_predict_config_ref.py
@@ -28,3 +28,24 @@ def test_predict_config_ref_defaults_to_none():
     dumped = cfg.model_dump()
     assert "ref" in dumped
     assert dumped["ref"] is None
+
+
+def test_predict_config_score_level_defaults_to_segment():
+    cfg = PredictConfig(**_base_kwargs())
+
+    assert cfg.score_level == "segment"
+
+
+def test_predict_config_accepts_system_score_level():
+    cfg = PredictConfig(**_base_kwargs(), score_level="system")
+
+    assert cfg.score_level == "system"
+
+
+def test_predict_config_rejects_invalid_score_level():
+    try:
+        PredictConfig(**_base_kwargs(), score_level="sentence")
+    except ValueError as exc:
+        assert "score_level" in str(exc)
+    else:
+        raise AssertionError("Expected invalid score_level validation error")

--- a/eole/tests/test_predict_config_ref.py
+++ b/eole/tests/test_predict_config_ref.py
@@ -1,0 +1,30 @@
+from eole.config.run import PredictConfig
+
+
+def _base_kwargs():
+    return {
+        "model_path": "org/model",
+        "src": "src.txt",
+        "tgt": "mt.txt",
+        "output": "scores.txt",
+    }
+
+
+def test_predict_config_accepts_ref_field():
+    cfg = PredictConfig(**_base_kwargs(), ref="ref.txt")
+
+    assert cfg.ref == "ref.txt"
+    assert cfg.src == "src.txt"
+    assert cfg.tgt == "mt.txt"
+
+    dumped = cfg.model_dump()
+    assert dumped["ref"] == "ref.txt"
+
+
+def test_predict_config_ref_defaults_to_none():
+    cfg = PredictConfig(**_base_kwargs())
+
+    assert cfg.ref is None
+    dumped = cfg.model_dump()
+    assert "ref" in dumped
+    assert dumped["ref"] is None

--- a/eole/tests/test_representation.py
+++ b/eole/tests/test_representation.py
@@ -1,0 +1,38 @@
+import unittest
+
+import torch
+
+from eole.modules.representation import RepresentationExtractor
+
+
+class TestRepresentationExtractor(unittest.TestCase):
+    def test_token_embeddings_returns_last_layer(self):
+        hidden_states = [torch.full((1, 2, 3), 1.0), torch.full((1, 2, 3), 2.0)]
+        extractor = RepresentationExtractor(layer="last")
+
+        result = extractor.token_embeddings(hidden_states, torch.ones(1, 2))
+
+        self.assertTrue(torch.equal(result, hidden_states[-1]))
+
+    def test_token_embeddings_returns_configured_layer(self):
+        hidden_states = [torch.full((1, 2, 3), 1.0), torch.full((1, 2, 3), 2.0)]
+        extractor = RepresentationExtractor(layer="0")
+
+        result = extractor.token_embeddings(hidden_states, torch.ones(1, 2))
+
+        self.assertTrue(torch.equal(result, hidden_states[0]))
+
+    def test_forward_cls_pool_uses_token_embeddings_first_token(self):
+        hidden_states = [
+            torch.tensor([[[1.0, 2.0], [3.0, 4.0]]]),
+            torch.tensor([[[5.0, 6.0], [7.0, 8.0]]]),
+        ]
+        extractor = RepresentationExtractor(layer="last", pool="cls")
+
+        result = extractor(hidden_states, torch.ones(1, 2))
+
+        self.assertTrue(torch.equal(result, torch.tensor([[5.0, 6.0]])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eole/utils/comet_scorer.py
+++ b/eole/utils/comet_scorer.py
@@ -1,5 +1,7 @@
 import os
 
+from tokenizers import Tokenizer
+
 from eole.config.config import Config
 from eole.config.data import NestedAllTransformsConfig
 from eole.transforms import get_transforms_cls, make_transforms
@@ -38,7 +40,11 @@ def build_comet_sentencepiece_transform(model, model_dir):
         ),
     )
     transforms = make_transforms(full_config, get_transforms_cls(["sentencepiece"]), model.vocabs)
-    return transforms["sentencepiece"]
+    transform = transforms["sentencepiece"]
+    tokenizer_json = os.path.join(model_dir, "tokenizer.json")
+    if os.path.exists(tokenizer_json):
+        transform.comet_tokenizer = Tokenizer.from_file(tokenizer_json)
+    return transform
 
 
 def encode_comet_texts_to_ids(texts, tokenizer, model):
@@ -51,4 +57,47 @@ def encode_comet_texts_to_ids(texts, tokenizer, model):
         pieces = tokenizer.tokenize_string(text, side="src", is_train=False)
         ids = [vocab.lookup_token(piece) for piece in pieces]
         encoded.append(([bos_id] + ids + [eos_id])[:max_length])
+    return encoded
+
+
+def _piece_offsets(text, pieces):
+    offsets = [(0, 0)]
+    cursor = 0
+    for piece in pieces:
+        surface = piece.replace("▁", " ")
+        if surface.startswith(" "):
+            cursor = min(len(text), cursor + len(surface) - len(surface.lstrip(" ")))
+            surface = surface.lstrip(" ")
+        if not surface:
+            offsets.append((cursor, cursor))
+            continue
+        start = text.find(surface, cursor)
+        if start < 0:
+            start = cursor
+        end = min(len(text), start + len(surface))
+        offsets.append((start, end))
+        cursor = end
+    offsets.append((0, 0))
+    return offsets
+
+
+def encode_comet_texts_to_ids_and_offsets(texts, tokenizer, model):
+    bos_id = model.bos_id
+    eos_id = model.eos_id
+    max_length = model.max_length
+    vocab = model.vocabs["src"]
+    encoded = []
+    for text in texts:
+        comet_tokenizer = getattr(tokenizer, "comet_tokenizer", None)
+        if comet_tokenizer is not None:
+            tokenized = comet_tokenizer.encode(text)
+            input_ids = tokenized.ids[:max_length]
+            offsets = tokenized.offsets[: len(input_ids)]
+            encoded.append({"ids": input_ids, "offsets": offsets, "decode_token_ids": comet_tokenizer.decode})
+            continue
+        pieces = tokenizer.tokenize_string(text, side="src", is_train=False)
+        ids = [vocab.lookup_token(piece) for piece in pieces]
+        input_ids = ([bos_id] + ids + [eos_id])[:max_length]
+        offsets = _piece_offsets(text, pieces)[: len(input_ids)]
+        encoded.append({"ids": input_ids, "offsets": offsets})
     return encoded

--- a/eole/utils/comet_scorer.py
+++ b/eole/utils/comet_scorer.py
@@ -1,0 +1,54 @@
+import os
+
+from eole.config.config import Config
+from eole.config.data import NestedAllTransformsConfig
+from eole.transforms import get_transforms_cls, make_transforms
+from eole.transforms.tokenize import BaseTokenizerConfig
+
+
+class CometScorerTransformConfig(Config):
+    share_vocab: bool = True
+    seed: int = 0
+    transforms_configs: NestedAllTransformsConfig
+
+
+def build_comet_sentencepiece_transform(model, model_dir):
+    tokenizer_model = os.path.join(model_dir, "sentencepiece.bpe.model")
+    if not os.path.exists(tokenizer_model):
+        tokenizer_model = os.path.join(model_dir, "sentencepiece.model")
+    if not os.path.exists(tokenizer_model):
+        raise FileNotFoundError(f"No sentencepiece model found in {model_dir}")
+
+    full_config = CometScorerTransformConfig(
+        share_vocab=True,
+        seed=0,
+        transforms_configs=NestedAllTransformsConfig(
+            sentencepiece=BaseTokenizerConfig(
+                src_subword_model=tokenizer_model,
+                tgt_subword_model=tokenizer_model,
+                src_subword_nbest=1,
+                tgt_subword_nbest=1,
+                src_subword_alpha=0.0,
+                tgt_subword_alpha=0.0,
+                src_subword_vocab="",
+                tgt_subword_vocab="",
+                src_vocab_threshold=0,
+                tgt_vocab_threshold=0,
+            )
+        ),
+    )
+    transforms = make_transforms(full_config, get_transforms_cls(["sentencepiece"]), model.vocabs)
+    return transforms["sentencepiece"]
+
+
+def encode_comet_texts_to_ids(texts, tokenizer, model):
+    bos_id = model.bos_id
+    eos_id = model.eos_id
+    max_length = model.max_length
+    vocab = model.vocabs["src"]
+    encoded = []
+    for text in texts:
+        pieces = tokenizer.tokenize_string(text, side="src", is_train=False)
+        ids = [vocab.lookup_token(piece) for piece in pieces]
+        encoded.append(([bos_id] + ids + [eos_id])[:max_length])
+    return encoded

--- a/eole/utils/encoder_scorer.py
+++ b/eole/utils/encoder_scorer.py
@@ -1,0 +1,44 @@
+import torch
+
+from eole.utils.misc import clear_gpu_cache
+
+
+def build_segment_rows(preds, texts_srcs, texts_refs, tokenizer, model, encode_texts_fn):
+    requires_reference = bool(getattr(model, "requires_reference", False))
+    input_segments = list(getattr(model, "input_segments", []))
+    needs_ref_ids = requires_reference or "ref" in input_segments
+    src_ids = encode_texts_fn(texts_srcs, tokenizer, model)
+    mt_ids = encode_texts_fn(preds, tokenizer, model)
+    ref_ids = encode_texts_fn(texts_refs, tokenizer, model) if needs_ref_ids and texts_refs is not None else None
+    rows = []
+    for idx in range(len(preds)):
+        row = {"src_ids": src_ids[idx], "mt_ids": mt_ids[idx]}
+        if ref_ids is not None:
+            row["ref_ids"] = ref_ids[idx]
+        rows.append(row)
+    return rows
+
+
+def predict_scores_with_oom_retry(model, rows, batch_size, logger=None, progress_callback=None):
+    batch_size = max(1, int(batch_size))
+    all_scores = []
+    i = 0
+    while i < len(rows):
+        current_bs = min(batch_size, len(rows) - i)
+        chunk = rows[i : i + current_bs]
+        try:
+            scores = model.predict_scores(chunk)
+            all_scores.extend(scores.tolist())
+            i += current_bs
+            if progress_callback is not None:
+                progress_callback(i)
+        except (torch.cuda.OutOfMemoryError, RuntimeError) as e:
+            if not isinstance(e, torch.cuda.OutOfMemoryError) and "out of memory" not in str(e).lower():
+                raise
+            if current_bs == 1:
+                raise
+            clear_gpu_cache()
+            batch_size = max(1, current_bs // 2)
+            if logger is not None:
+                logger.warning("OOM at batch %d; halving to %d", current_bs, batch_size)
+    return all_scores

--- a/eole/utils/encoder_scorer.py
+++ b/eole/utils/encoder_scorer.py
@@ -4,17 +4,32 @@ from eole.utils.misc import clear_gpu_cache
 
 
 def build_segment_rows(preds, texts_srcs, texts_refs, tokenizer, model, encode_texts_fn):
+    if len(texts_srcs) != len(preds):
+        raise ValueError(f"preds and texts_srcs lengths differ: {len(preds)} vs {len(texts_srcs)}")
+    if texts_refs is not None and len(texts_refs) != len(preds):
+        raise ValueError(f"preds and texts_refs lengths differ: {len(preds)} vs {len(texts_refs)}")
+
     requires_reference = bool(getattr(model, "requires_reference", False))
     input_segments = list(getattr(model, "input_segments", []))
     needs_ref_ids = requires_reference or "ref" in input_segments
     src_ids = encode_texts_fn(texts_srcs, tokenizer, model)
     mt_ids = encode_texts_fn(preds, tokenizer, model)
     ref_ids = encode_texts_fn(texts_refs, tokenizer, model) if needs_ref_ids and texts_refs is not None else None
+
+    def _ids(item):
+        return item["ids"] if isinstance(item, dict) else item
+
     rows = []
     for idx in range(len(preds)):
-        row = {"src_ids": src_ids[idx], "mt_ids": mt_ids[idx]}
+        mt = mt_ids[idx]
+        row = {"src_ids": _ids(src_ids[idx]), "mt_ids": _ids(mt), "mt_text": preds[idx]}
+        if isinstance(mt, dict):
+            if "offsets" in mt:
+                row["mt_offsets"] = mt["offsets"]
+            if "decode_token_ids" in mt:
+                row["decode_token_ids"] = mt["decode_token_ids"]
         if ref_ids is not None:
-            row["ref_ids"] = ref_ids[idx]
+            row["ref_ids"] = _ids(ref_ids[idx])
         rows.append(row)
     return rows
 

--- a/recipes/scoring/README.md
+++ b/recipes/scoring/README.md
@@ -1,0 +1,14 @@
+# Scoring Recipes
+
+This directory contains validated examples for EOLE scoring models and metrics.
+
+## Native COMET
+
+See [`comet_native/`](comet_native/) for native scoring with converted
+[Unbabel COMET](https://github.com/Unbabel/COMET) / COMET-KIWI models:
+
+- `EOLE-COMET` (reference-based)
+- `EOLE-COMET-KIWI` (reference-free)
+
+Converted COMET models use the generic encoder-only `transformer_encoder_scorer`
+architecture with the COMET-specific `scoring_type: comet` specialization.

--- a/recipes/scoring/README.md
+++ b/recipes/scoring/README.md
@@ -5,10 +5,11 @@ This directory contains validated examples for EOLE scoring models and metrics.
 ## Native COMET
 
 See [`comet_native/`](comet_native/) for native scoring with converted
-[Unbabel COMET](https://github.com/Unbabel/COMET) / COMET-KIWI models:
+[Unbabel COMET](https://github.com/Unbabel/COMET) / COMET-KIWI / XCOMET models:
 
 - `EOLE-COMET` (reference-based)
 - `EOLE-COMET-KIWI` (reference-free)
+- `EOLE-XCOMET` (reference-based xCOMET scalar score; span parity validation supported by the recipe harness)
 
 Converted COMET models use the generic encoder-only `transformer_encoder_scorer`
 architecture with the COMET-specific `scoring_type: comet` specialization.

--- a/recipes/scoring/comet_native/README.md
+++ b/recipes/scoring/comet_native/README.md
@@ -5,6 +5,7 @@ This recipe shows how to use native EOLE scoring with converted
 
 - `EOLE-COMET` (reference-based)
 - `EOLE-COMET-KIWI` (reference-free)
+- `EOLE-XCOMET` (reference-based, xCOMET scalar score with explainable spans validated internally)
 
 Converted COMET models are represented as EOLE `transformer_encoder_scorer`
 models with the COMET-specific `scoring_type: comet` specialization. Direct
@@ -24,6 +25,7 @@ For gated models, pass a token:
 
 ```bash
 eole convert COMET --model Unbabel/wmt23-cometkiwi-da-xl --token "$HF_TOKEN" --output "$EOLE_MODEL_DIR/comet/Unbabel--wmt23-cometkiwi-da-xl"
+eole convert COMET --model Unbabel/XCOMET-XL --token "$HF_TOKEN" --output "$EOLE_MODEL_DIR/comet/Unbabel--XCOMET-XL"
 ```
 
 ## 2) Use `EOLE-COMET` in a training config
@@ -50,7 +52,21 @@ comet_batch_size: 64
 
 `EOLE-COMET-KIWI` is reference-free and scores from source+hypothesis only.
 
-## 4) Parity check vs Unbabel COMET
+## 4) Use `EOLE-XCOMET` in a training config
+
+Set in your train YAML:
+
+```yaml
+valid_metrics: ["EOLE-XCOMET"]
+comet_model: "${EOLE_MODEL_DIR}/comet/Unbabel--XCOMET-XL"
+comet_batch_size: 64
+```
+
+`EOLE-XCOMET` is reference-based and reports the scalar xCOMET score as a
+validation metric. Native prediction can compute xCOMET span metadata internally;
+the validation metric interface currently emits only the scalar score.
+
+## 5) Parity check vs Unbabel COMET
 
 Use the reusable parity harness to compare EOLE native scores against
 [Unbabel COMET](https://github.com/Unbabel/COMET):
@@ -76,7 +92,20 @@ python recipes/scoring/comet_native/parity_check.py \
   --output /tmp/parity_wmt23_xl.json
 ```
 
-## 5) Direct CLI scoring with `eole predict`
+For XCOMET, the parity harness compares scalar scores, MQM scores, and decoded
+error spans against [Unbabel COMET](https://github.com/Unbabel/COMET):
+
+```bash
+python recipes/scoring/comet_native/parity_check.py \
+  --src /path/to/src.txt \
+  --mt /path/to/mt.txt \
+  --ref /path/to/ref.txt \
+  --hf-model Unbabel/XCOMET-XL \
+  --eole-model "${EOLE_MODEL_DIR}/comet/Unbabel--XCOMET-XL" \
+  --output /tmp/parity_xcomet_xl.json
+```
+
+## 6) Direct CLI scoring with `eole predict`
 
 For `transformer_encoder_scorer` models, use:
 
@@ -104,5 +133,17 @@ eole predict \
   --src /path/to/src.txt \
   --tgt /path/to/mt.txt \
   --output /path/to/scores.txt \
+  --with_score
+```
+
+XCOMET (`EOLE-XCOMET`) score-only CLI output:
+
+```bash
+eole predict \
+  --model_path "$EOLE_MODEL_DIR/comet/Unbabel--XCOMET-XL" \
+  --src /path/to/src.txt \
+  --tgt /path/to/mt.txt \
+  --ref /path/to/ref.txt \
+  --output /path/to/xcomet-scores.txt \
   --with_score
 ```

--- a/recipes/scoring/comet_native/README.md
+++ b/recipes/scoring/comet_native/README.md
@@ -147,3 +147,32 @@ eole predict \
   --output /path/to/xcomet-scores.txt \
   --with_score
 ```
+
+By default, `eole predict --with_score` writes one segment score per input line:
+
+```text
+0.812345
+0.734567
+0.901234
+```
+
+To emit a single system-level score, use `--score_level system`:
+
+```bash
+eole predict \
+  --model_path "$EOLE_MODEL_DIR/comet/Unbabel--wmt22-comet-da" \
+  --src /path/to/src.txt \
+  --tgt /path/to/mt.txt \
+  --ref /path/to/ref.txt \
+  --output /path/to/system-score.txt \
+  --with_score \
+  --score_level system
+```
+
+`score_level: system` writes one numeric line containing the arithmetic mean of
+the segment scores, similar to Unbabel COMET's `--only_system` mode but using
+EOLE's score-file format:
+
+```text
+0.816049
+```

--- a/recipes/scoring/comet_native/README.md
+++ b/recipes/scoring/comet_native/README.md
@@ -1,0 +1,108 @@
+# Native EOLE COMET Scoring
+
+This recipe shows how to use native EOLE scoring with converted
+[Unbabel COMET](https://github.com/Unbabel/COMET) models:
+
+- `EOLE-COMET` (reference-based)
+- `EOLE-COMET-KIWI` (reference-free)
+
+Converted COMET models are represented as EOLE `transformer_encoder_scorer`
+models with the COMET-specific `scoring_type: comet` specialization. Direct
+inference from Unbabel Hugging Face model IDs is not supported here; convert the
+COMET checkpoint first.
+
+## 1) Convert COMET models to EOLE artifacts
+
+```bash
+export EOLE_MODEL_DIR=~/Development/Models/eole
+
+eole convert COMET --model Unbabel/wmt22-comet-da --output "$EOLE_MODEL_DIR/comet/Unbabel--wmt22-comet-da"
+eole convert COMET --model Unbabel/wmt22-cometkiwi-da --output "$EOLE_MODEL_DIR/comet/Unbabel--wmt22-cometkiwi-da"
+```
+
+For gated models, pass a token:
+
+```bash
+eole convert COMET --model Unbabel/wmt23-cometkiwi-da-xl --token "$HF_TOKEN" --output "$EOLE_MODEL_DIR/comet/Unbabel--wmt23-cometkiwi-da-xl"
+```
+
+## 2) Use `EOLE-COMET` in a training config
+
+Set in your train YAML:
+
+```yaml
+valid_metrics: ["EOLE-COMET"]
+comet_model: "${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-comet-da"
+comet_batch_size: 64
+```
+
+The reference-based scorer requires references in the validation corpus.
+
+## 3) Use `EOLE-COMET-KIWI` in a training config
+
+Set in your train YAML:
+
+```yaml
+valid_metrics: ["EOLE-COMET-KIWI"]
+comet_model: "${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-cometkiwi-da"
+comet_batch_size: 64
+```
+
+`EOLE-COMET-KIWI` is reference-free and scores from source+hypothesis only.
+
+## 4) Parity check vs Unbabel COMET
+
+Use the reusable parity harness to compare EOLE native scores against
+[Unbabel COMET](https://github.com/Unbabel/COMET):
+
+```bash
+python recipes/scoring/comet_native/parity_check.py \
+  --src /path/to/src.txt \
+  --mt /path/to/mt.txt \
+  --ref /path/to/ref.txt \
+  --hf-model Unbabel/wmt22-comet-da \
+  --eole-model "${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-comet-da" \
+  --output /tmp/parity_wmt22_da.json
+```
+
+For KIWI / reference-free:
+
+```bash
+python recipes/scoring/comet_native/parity_check.py \
+  --src /path/to/src.txt \
+  --mt /path/to/mt.txt \
+  --hf-model Unbabel/wmt23-cometkiwi-da-xl \
+  --eole-model "${EOLE_MODEL_DIR}/comet/Unbabel--wmt23-cometkiwi-da-xl" \
+  --output /tmp/parity_wmt23_xl.json
+```
+
+## 5) Direct CLI scoring with `eole predict`
+
+For `transformer_encoder_scorer` models, use:
+
+- `--src`: source sentences
+- `--tgt`: MT hypotheses
+- `--ref`: references (required only for reference-based models)
+
+Reference-based (`EOLE-COMET`):
+
+```bash
+eole predict \
+  --model_path "$EOLE_MODEL_DIR/comet/Unbabel--wmt22-comet-da" \
+  --src /path/to/src.txt \
+  --tgt /path/to/mt.txt \
+  --ref /path/to/ref.txt \
+  --output /path/to/scores.txt \
+  --with_score
+```
+
+Reference-free (`EOLE-COMET-KIWI`):
+
+```bash
+eole predict \
+  --model_path "$EOLE_MODEL_DIR/comet/Unbabel--wmt22-cometkiwi-da" \
+  --src /path/to/src.txt \
+  --tgt /path/to/mt.txt \
+  --output /path/to/scores.txt \
+  --with_score
+```

--- a/recipes/scoring/comet_native/eole-comet-kiwi-inference.yaml
+++ b/recipes/scoring/comet_native/eole-comet-kiwi-inference.yaml
@@ -1,4 +1,4 @@
-model_path: ["${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-cometkiwi-da-native"]
+model_path: ["${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-cometkiwi-da"]
 
 seed: 42
 batch_type: sents

--- a/recipes/scoring/comet_native/eole-comet-kiwi-inference.yaml
+++ b/recipes/scoring/comet_native/eole-comet-kiwi-inference.yaml
@@ -1,0 +1,12 @@
+model_path: ["${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-cometkiwi-da-native"]
+
+seed: 42
+batch_type: sents
+batch_size: 512
+world_size: 1
+gpu_ranks: [0]
+# fp16 endorsed by upstream (Unbabel/wmt23-cometkiwi-da-xl/discussions/3) —
+# 2× faster, 2× less RAM, no accuracy change vs fp32.
+compute_dtype: fp16
+report_time: true
+src: null

--- a/recipes/scoring/comet_native/eole-comet-valid-metrics.yaml
+++ b/recipes/scoring/comet_native/eole-comet-valid-metrics.yaml
@@ -1,0 +1,3 @@
+valid_metrics: ["EOLE-COMET"]
+comet_model: "${EOLE_MODEL_DIR}/comet/Unbabel--wmt22-comet-da"
+comet_batch_size: 64

--- a/recipes/scoring/comet_native/eole-xcomet-inference.yaml
+++ b/recipes/scoring/comet_native/eole-xcomet-inference.yaml
@@ -1,0 +1,10 @@
+model_path: ["${EOLE_MODEL_DIR}/comet/Unbabel--XCOMET-XL"]
+
+seed: 42
+batch_type: sents
+batch_size: 64
+world_size: 1
+gpu_ranks: [0]
+compute_dtype: fp32
+report_time: true
+src: null

--- a/recipes/scoring/comet_native/eole-xcomet-valid-metrics.yaml
+++ b/recipes/scoring/comet_native/eole-xcomet-valid-metrics.yaml
@@ -1,0 +1,3 @@
+valid_metrics: ["EOLE-XCOMET"]
+comet_model: "${EOLE_MODEL_DIR}/comet/Unbabel--XCOMET-XL"
+comet_batch_size: 64

--- a/recipes/scoring/comet_native/parity_check.py
+++ b/recipes/scoring/comet_native/parity_check.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from comet import download_model, load_from_checkpoint
+
+from eole.models.model import EncoderScoringModel
+from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Compare unbabel-comet and native EOLE COMET parity.")
+    p.add_argument("--src", required=True, help="Source text file (one segment per line)")
+    p.add_argument("--mt", required=True, help="MT hypothesis file (one segment per line)")
+    p.add_argument("--ref", default=None, help="Reference file for reference-based COMET")
+    p.add_argument("--hf-model", required=True, help="Baseline model ID (e.g. Unbabel/wmt22-cometkiwi-da)")
+    p.add_argument("--eole-model", required=True, help="Converted EOLE COMET model directory")
+    p.add_argument("--batch-size", type=int, default=8)
+    p.add_argument("--output", default=None, help="Optional path for JSON report")
+    return p.parse_args()
+
+
+def read_lines(path):
+    return Path(path).read_text(encoding="utf-8").splitlines()
+
+
+def main():
+    args = parse_args()
+    src = read_lines(args.src)
+    mt = read_lines(args.mt)
+    ref = read_lines(args.ref) if args.ref else None
+    if len(src) != len(mt):
+        raise ValueError("src and mt files must have same number of lines")
+    if ref is not None and len(ref) != len(src):
+        raise ValueError("ref must have same number of lines as src")
+
+    baseline = load_from_checkpoint(download_model(args.hf_model))
+    if ref is None:
+        data = [{"src": s, "mt": m} for s, m in zip(src, mt)]
+        eole_scorer = EoleCometKiwiScorer(
+            SimpleNamespace(comet_model=args.eole_model, comet_batch_size=args.batch_size)
+        )
+    else:
+        data = [{"src": s, "mt": m, "ref": r} for s, m, r in zip(src, mt, ref)]
+        eole_scorer = EoleCometScorer(SimpleNamespace(comet_model=args.eole_model, comet_batch_size=args.batch_size))
+
+    baseline_out = baseline.predict(data, batch_size=args.batch_size, gpus=0, num_workers=1, progress_bar=False)
+    eole_system = eole_scorer.compute_score(mt, ref, src)
+
+    runtime = EncoderScoringModel.from_model_dir(args.eole_model, device="cpu")
+    tokenizer = eole_scorer._build_sp_transform(runtime, args.eole_model)
+    src_ids = eole_scorer._encode_texts(src, tokenizer, runtime)
+    mt_ids = eole_scorer._encode_texts(mt, tokenizer, runtime)
+    ref_ids = eole_scorer._encode_texts(ref, tokenizer, runtime) if ref is not None else None
+    runtime_rows = []
+    for i in range(len(src)):
+        row = {"src_ids": src_ids[i], "mt_ids": mt_ids[i]}
+        if ref_ids is not None:
+            row["ref_ids"] = ref_ids[i]
+        runtime_rows.append(row)
+    eole_scores = []
+    for i in range(0, len(runtime_rows), args.batch_size):
+        eole_scores.extend(runtime.predict_scores(runtime_rows[i : i + args.batch_size]).tolist())
+
+    dif = [abs(a - b) for a, b in zip(baseline_out.scores, eole_scores)]
+    report = {
+        "hf_model": args.hf_model,
+        "eole_model": args.eole_model,
+        "n": len(src),
+        "baseline_system": float(baseline_out.system_score),
+        "eole_system": float(eole_system),
+        "delta_system": float(abs(baseline_out.system_score - eole_system)),
+        "sentence_mae": float(sum(dif) / len(dif)),
+        "sentence_max_abs": float(max(dif)),
+    }
+
+    print(json.dumps(report, indent=2))
+    if args.output:
+        Path(args.output).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/scoring/comet_native/parity_check.py
+++ b/recipes/scoring/comet_native/parity_check.py
@@ -8,6 +8,7 @@ from comet import download_model, load_from_checkpoint
 
 from eole.models.model import EncoderScoringModel
 from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer
+from eole.utils.encoder_scorer import build_segment_rows
 
 
 def parse_args():
@@ -18,12 +19,82 @@ def parse_args():
     p.add_argument("--hf-model", required=True, help="Baseline model ID (e.g. Unbabel/wmt22-cometkiwi-da)")
     p.add_argument("--eole-model", required=True, help="Converted EOLE COMET model directory")
     p.add_argument("--batch-size", type=int, default=8)
+    p.add_argument("--device", default="cpu", help="Device for native EOLE scoring, e.g. cpu, mps, cuda:0")
+    p.add_argument("--num-workers", type=int, default=1, help="DataLoader workers for Unbabel COMET baseline")
     p.add_argument("--output", default=None, help="Optional path for JSON report")
     return p.parse_args()
 
 
 def read_lines(path):
     return Path(path).read_text(encoding="utf-8").splitlines()
+
+
+def _as_list(value):
+    if value is None:
+        return None
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
+def _metadata_get(metadata, key):
+    if metadata is None:
+        return None
+    if hasattr(metadata, key):
+        return getattr(metadata, key)
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    return None
+
+
+def _span_mismatches(baseline_spans, eole_spans, limit=10):
+    mismatches = []
+    for idx, (baseline_sentence, eole_sentence) in enumerate(zip(baseline_spans, eole_spans)):
+        if len(baseline_sentence) != len(eole_sentence):
+            mismatches.append(
+                {
+                    "index": idx,
+                    "reason": "span_count",
+                    "baseline": baseline_sentence,
+                    "eole": eole_sentence,
+                }
+            )
+            if len(mismatches) >= limit:
+                break
+            continue
+        for span_idx, (baseline_span, eole_span) in enumerate(zip(baseline_sentence, eole_sentence)):
+            baseline_core = {k: baseline_span.get(k) for k in ["text", "severity", "start", "end"]}
+            eole_core = {k: eole_span.get(k) for k in ["text", "severity", "start", "end"]}
+            if baseline_core != eole_core:
+                mismatches.append(
+                    {
+                        "index": idx,
+                        "span_index": span_idx,
+                        "reason": "span_fields",
+                        "baseline": baseline_span,
+                        "eole": eole_span,
+                    }
+                )
+                if len(mismatches) >= limit:
+                    return mismatches
+    if len(baseline_spans) != len(eole_spans):
+        mismatches.append(
+            {
+                "reason": "sentence_count",
+                "baseline_count": len(baseline_spans),
+                "eole_count": len(eole_spans),
+            }
+        )
+    return mismatches
+
+
+def _numeric_diff(a, b):
+    if a is None or b is None:
+        return None
+    dif = [abs(float(x) - float(y)) for x, y in zip(a, b)]
+    if not dif:
+        return {"mae": 0.0, "max_abs": 0.0}
+    return {"mae": float(sum(dif) / len(dif)), "max_abs": float(max(dif))}
 
 
 def main():
@@ -46,23 +117,27 @@ def main():
         data = [{"src": s, "mt": m, "ref": r} for s, m, r in zip(src, mt, ref)]
         eole_scorer = EoleCometScorer(SimpleNamespace(comet_model=args.eole_model, comet_batch_size=args.batch_size))
 
-    baseline_out = baseline.predict(data, batch_size=args.batch_size, gpus=0, num_workers=1, progress_bar=False)
-    eole_system = eole_scorer.compute_score(mt, ref, src)
+    baseline_out = baseline.predict(
+        data, batch_size=args.batch_size, gpus=0, num_workers=args.num_workers, progress_bar=False
+    )
 
-    runtime = EncoderScoringModel.from_model_dir(args.eole_model, device="cpu")
+    runtime = EncoderScoringModel.from_model_dir(args.eole_model, device=args.device)
     tokenizer = eole_scorer._build_sp_transform(runtime, args.eole_model)
-    src_ids = eole_scorer._encode_texts(src, tokenizer, runtime)
-    mt_ids = eole_scorer._encode_texts(mt, tokenizer, runtime)
-    ref_ids = eole_scorer._encode_texts(ref, tokenizer, runtime) if ref is not None else None
-    runtime_rows = []
-    for i in range(len(src)):
-        row = {"src_ids": src_ids[i], "mt_ids": mt_ids[i]}
-        if ref_ids is not None:
-            row["ref_ids"] = ref_ids[i]
-        runtime_rows.append(row)
+    runtime_rows = build_segment_rows(mt, src, ref, tokenizer, runtime, encode_texts_fn=eole_scorer._encode_texts)
     eole_scores = []
+    eole_metadata = None
     for i in range(0, len(runtime_rows), args.batch_size):
-        eole_scores.extend(runtime.predict_scores(runtime_rows[i : i + args.batch_size]).tolist())
+        chunk = runtime_rows[i : i + args.batch_size]
+        if getattr(runtime, "class_identifier", None) == "xcomet_metric":
+            chunk_out = runtime.predict_xcomet(chunk)
+            eole_scores.extend(chunk_out["scores"])
+            if eole_metadata is None:
+                eole_metadata = {key: [] for key in chunk_out["metadata"]}
+            for key, value in chunk_out["metadata"].items():
+                eole_metadata[key].extend(value)
+        else:
+            eole_scores.extend(runtime.predict_scores(chunk).tolist())
+    eole_system = float(sum(eole_scores) / len(eole_scores))
 
     dif = [abs(a - b) for a, b in zip(baseline_out.scores, eole_scores)]
     report = {
@@ -75,6 +150,18 @@ def main():
         "sentence_mae": float(sum(dif) / len(dif)),
         "sentence_max_abs": float(max(dif)),
     }
+
+    if getattr(runtime, "class_identifier", None) == "xcomet_metric":
+        baseline_metadata = getattr(baseline_out, "metadata", None)
+        baseline_spans = _metadata_get(baseline_metadata, "error_spans") or []
+        eole_spans = (eole_metadata or {}).get("error_spans", [])
+        baseline_mqm = _as_list(_metadata_get(baseline_metadata, "mqm_scores"))
+        eole_mqm = (eole_metadata or {}).get("mqm_scores")
+        report["xcomet"] = {
+            "mqm_scores": _numeric_diff(baseline_mqm, eole_mqm),
+            "span_sentence_mismatches": len(_span_mismatches(baseline_spans, eole_spans, limit=len(src))),
+            "span_mismatch_examples": _span_mismatches(baseline_spans, eole_spans),
+        }
 
     print(json.dumps(report, indent=2))
     if args.output:


### PR DESCRIPTION
This pull request introduces support for native COMET scoring in EOLE, adds configuration options for RoBERTa/XLM-R-style encoder and embeddings, and improves model loading flexibility. It includes new documentation, configuration fields, and implementation changes to support these features.

**COMET Scoring Support:**

- Added `TransformerEncoderScorerModelConfig` for native COMET and COMET-KIWI models, including relevant fields such as `scoring_type`, `class_identifier`, and `input_segments`. This enables EOLE to natively run COMET metrics using a specialized encoder-only architecture.
- Updated documentation to describe how to convert and use COMET/COMET-KIWI models in EOLE, including example commands and configuration usage. [[1]](diffhunk://#diff-6265ab9076ca83aecba3f9b7a9d38de4a92e66d248902e9130774bdfa3312b0cL19-R19) [[2]](diffhunk://#diff-6265ab9076ca83aecba3f9b7a9d38de4a92e66d248902e9130774bdfa3312b0cR50-R66)
- Added `comet_device` field to `ScoringConfig` to control device selection for COMET scoring.
- Added `ref` field to `PredictConfig` for reference-based scoring models.

**RoBERTa/XLM-R-style Encoder and Embeddings:**

- Added `embedding_type`, `embedding_layer_norm`, and `token_type_vocab_size` fields to `EmbeddingsConfig`, and implemented logic to use `RobertaEmbeddings` when requested. [[1]](diffhunk://#diff-59990533fdece6c455150351336277fe7f351f2adb5f42de489eb8d61d3de1daR16) [[2]](diffhunk://#diff-59990533fdece6c455150351336277fe7f351f2adb5f42de489eb8d61d3de1daR49-R56) [[3]](diffhunk://#diff-f91922182a173d727c3734518a3eba4fb2553d8fda12e67c94428ffe50f84350L26-R30) [[4]](diffhunk://#diff-f91922182a173d727c3734518a3eba4fb2553d8fda12e67c94428ffe50f84350R74-R85)
- Added `encoder_layer_style` and `final_encoder_layer_norm` to `TransformerEncoderConfig` for post-norm and RoBERTa/XLM-R-style transformer layers, and updated `TransformerEncoderLayer` and `TransformerEncoder` to implement these options. [[1]](diffhunk://#diff-59990533fdece6c455150351336277fe7f351f2adb5f42de489eb8d61d3de1daR385-R392) [[2]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5R26-R33) [[3]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5R43-R47) [[4]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5R58-R61) [[5]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5L69-R96) [[6]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5L91-R110) [[7]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5L123-R151) [[8]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5L139-R166) [[9]](diffhunk://#diff-8302b7cbdc81b4c2b4a23abb2a91958289461326040755986de14048d88c43e5R181-R190)

**Model Loading Improvements:**

- Improved safe state dict loading to allow for more flexible checkpoint key mapping and tracking of loaded checkpoint keys. [[1]](diffhunk://#diff-f91922182a173d727c3734518a3eba4fb2553d8fda12e67c94428ffe50f84350R607-R625) [[2]](diffhunk://#diff-f91922182a173d727c3734518a3eba4fb2553d8fda12e67c94428ffe50f84350R766) [[3]](diffhunk://#diff-f91922182a173d727c3734518a3eba4fb2553d8fda12e67c94428ffe50f84350R777)

These changes collectively enable EOLE to natively support COMET metrics, improve compatibility with RoBERTa/XLM-R-style models, and enhance model loading robustness.