### PR TITLE
Fix XCOMET reference-optional scoring in EOLE predict

### DIFF
--- a/eole/bin/convert/convert_COMET.py
+++ b/eole/bin/convert/convert_COMET.py
@@ -96,7 +96,7 @@ def _build_model_config(args_model, hparams, encoder_config):
     input_segments = hparams.get("input_segments", ["mt", "src", "ref"])
     class_identifier = hparams["class_identifier"]
     requires_reference = class_identifier == "regression_metric" or (
-        class_identifier in {"unified_metric", "xcomet_metric"} and "ref" in input_segments
+        class_identifier == "unified_metric" and "ref" in input_segments
     )
 
     return {

--- a/eole/config/models.py
+++ b/eole/config/models.py
@@ -1157,7 +1157,7 @@ class TransformerEncoderScorerModelConfig(BaseModelConfig):
     def sync_family_fields(self):
         if self.scoring_type == "comet":
             expected_requires_reference = self.class_identifier == "regression_metric" or (
-                self.class_identifier in {"unified_metric", "xcomet_metric"} and "ref" in self.input_segments
+                self.class_identifier == "unified_metric" and "ref" in self.input_segments
             )
             if self.requires_reference != expected_requires_reference:
                 object.__setattr__(self, "requires_reference", expected_requires_reference)

--- a/eole/scorers/eole_comet.py
+++ b/eole/scorers/eole_comet.py
@@ -66,10 +66,11 @@ class _EoleCometBase(Scorer):
             raise ValueError(
                 f"{self.metric_name} expects a converted model with " f"class_identifier in {{{expected_text}}}."
             )
-        if self.expect_reference and not model.requires_reference:
-            raise ValueError(f"{self.metric_name} expects a reference-based converted model.")
-        if not self.expect_reference and model.requires_reference:
-            raise ValueError(f"{self.metric_name} expects a reference-free converted model.")
+        if self.expect_reference is not None:
+            if self.expect_reference and not model.requires_reference:
+                raise ValueError(f"{self.metric_name} expects a reference-based converted model.")
+            if not self.expect_reference and model.requires_reference:
+                raise ValueError(f"{self.metric_name} expects a reference-free converted model.")
 
     def _build_sp_transform(self, model, model_dir):
         return build_comet_sentencepiece_transform(model, model_dir)
@@ -144,5 +145,5 @@ class EoleCometKiwiScorer(_EoleCometBase):
 class EoleXCometScorer(_EoleCometBase):
     default_model = "eole-nlp/xcomet-xl-eole-fp16"
     metric_name = "EOLE-XCOMET"
-    expect_reference = True
+    expect_reference = None
     expected_class_identifier = "xcomet_metric"

--- a/eole/tests/test_convert_comet.py
+++ b/eole/tests/test_convert_comet.py
@@ -3,7 +3,17 @@ import unittest
 
 import torch
 
-from eole.bin.convert.convert_COMET import CometConverter, _cast_state_dict
+from eole.bin.convert.convert_COMET import CometConverter, _build_model_config, _cast_state_dict
+
+
+def _encoder_config(architecture="XLMRobertaForMaskedLM"):
+    return {
+        "architectures": [architecture],
+        "hidden_size": 1024,
+        "num_hidden_layers": 24,
+        "num_attention_heads": 16,
+        "intermediate_size": 4096,
+    }
 
 
 class TestConvertComet(unittest.TestCase):
@@ -26,6 +36,25 @@ class TestConvertComet(unittest.TestCase):
         args = parser.parse_args(["--model", "Unbabel/wmt22-comet-da"])
 
         self.assertEqual(args.dtype, "fp32")
+
+    def test_xcomet_conversion_does_not_require_reference(self):
+        config = _build_model_config(
+            "Unbabel/XCOMET-XL",
+            {"class_identifier": "xcomet_metric", "input_segments": ["mt", "src", "ref"]},
+            _encoder_config("XLMRobertaXLForMaskedLM"),
+        )
+
+        self.assertFalse(config["requires_reference"])
+        self.assertEqual(config["input_segments"], ["mt", "src", "ref"])
+
+    def test_regression_metric_conversion_still_requires_reference(self):
+        config = _build_model_config(
+            "Unbabel/wmt22-comet-da",
+            {"class_identifier": "regression_metric", "input_segments": ["mt", "src", "ref"]},
+            _encoder_config(),
+        )
+
+        self.assertTrue(config["requires_reference"])
 
 
 if __name__ == "__main__":

--- a/eole/tests/test_encoder_scorer.py
+++ b/eole/tests/test_encoder_scorer.py
@@ -287,14 +287,14 @@ class TestEncoderScorer(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "texts_refs"):
             build_segment_rows(["mt", "mt2"], ["src", "src2"], ["ref"], FakeTokenizer(), model, _encode_texts_for_test)
 
-    def test_xcomet_config_sets_reference_requirement_from_segments(self):
+    def test_xcomet_config_does_not_require_reference_from_segments(self):
         config = TransformerEncoderScorerModelConfig(
             class_identifier="xcomet_metric",
-            requires_reference=False,
+            requires_reference=True,
             input_segments=["mt", "src", "ref"],
         )
 
-        self.assertTrue(config.requires_reference)
+        self.assertFalse(config.requires_reference)
         self.assertEqual(config.error_labels, ["minor", "major", "critical"])
 
     def test_xcomet_config_rejects_custom_error_labels(self):

--- a/eole/tests/test_eole_comet_scorer.py
+++ b/eole/tests/test_eole_comet_scorer.py
@@ -8,11 +8,19 @@ from eole.scorers.eole_comet import EoleCometScorer, EoleCometKiwiScorer, EoleXC
 
 
 class FakeRuntime:
-    def __init__(self, requires_reference, scores, class_identifier="regression_metric", scoring_type="comet"):
+    def __init__(
+        self,
+        requires_reference,
+        scores,
+        class_identifier="regression_metric",
+        scoring_type="comet",
+        input_segments=None,
+    ):
         self.requires_reference = requires_reference
         self._scores = scores
         self.class_identifier = class_identifier
         self.scoring_type = scoring_type
+        self.input_segments = input_segments or []
 
     def predict_scores(self, rows):
         import torch
@@ -204,6 +212,24 @@ class TestEoleCometScorers(unittest.TestCase):
             ),
         ):
             score = scorer.compute_score(["a", "b"], ["r1", "r2"], ["s1", "s2"])
+
+        self.assertAlmostEqual(score, 0.4, places=6)
+
+    def test_eole_xcomet_accepts_reference_free_input(self):
+        scorer = EoleXCometScorer(SimpleNamespace(comet_model="dummy", comet_batch_size=8))
+        fake_runtime = FakeRuntime(
+            requires_reference=False,
+            scores=[0.2, 0.6],
+            class_identifier="xcomet_metric",
+            input_segments=["mt", "src", "ref"],
+        )
+        with (
+            patch("eole.scorers.eole_comet._resolve_model_dir", return_value="dummy"),
+            patch("eole.scorers.eole_comet.EncoderScoringModel.from_model_dir", return_value=fake_runtime),
+            patch.object(EoleXCometScorer, "_build_sp_transform", return_value=object()),
+            patch.object(EoleXCometScorer, "_encode_texts", side_effect=[[[0, 1], [0, 1]], [[0, 1], [0, 1]]]),
+        ):
+            score = scorer.compute_score(["a", "b"], None, ["s1", "s2"])
 
         self.assertAlmostEqual(score, 0.4, places=6)
 

--- a/recipes/scoring/README.md
+++ b/recipes/scoring/README.md
@@ -17,7 +17,7 @@ See [`comet_native/`](comet_native/) for native scoring with converted
 
 - `EOLE-COMET` (reference-based)
 - `EOLE-COMET-KIWI` (reference-free)
-- `EOLE-XCOMET` (reference-based xCOMET scalar score; span parity validation supported by the recipe harness)
+- `EOLE-XCOMET` (reference-optional xCOMET scalar score; span parity validation supported by the recipe harness)
 
 Converted COMET models use the generic encoder-only `transformer_encoder_scorer`
 architecture with the COMET-specific `scoring_type: comet` specialization.

--- a/recipes/scoring/comet_native/README.md
+++ b/recipes/scoring/comet_native/README.md
@@ -5,7 +5,7 @@ This recipe shows how to use native EOLE scoring with pre-converted
 
 - `EOLE-COMET` (reference-based)
 - `EOLE-COMET-KIWI` (reference-free)
-- `EOLE-XCOMET` (reference-based, xCOMET scalar score with explainable spans validated internally)
+- `EOLE-XCOMET` (reference-optional, xCOMET scalar score with explainable spans validated internally)
 
 Converted COMET models are represented as EOLE `transformer_encoder_scorer`
 models with the COMET-specific `scoring_type: comet` specialization. Raw
@@ -23,7 +23,7 @@ for all published COMET, COMET-KIWI, and XCOMET EOLE conversions.
 | --- | --- | --- |
 | `EOLE-COMET` | `eole-nlp/wmt22-comet-da-eole-fp16` | Yes |
 | `EOLE-COMET-KIWI` | `eole-nlp/wmt23-cometkiwi-da-xl-eole-fp16` | No |
-| `EOLE-XCOMET` | `eole-nlp/xcomet-xl-eole-fp16` | Yes |
+| `EOLE-XCOMET` | `eole-nlp/xcomet-xl-eole-fp16` | Optional |
 
 For public repos, no local conversion is required. For gated/private repos,
 authenticate with `hf auth login` or set `HF_TOKEN`. For direct `eole predict`,
@@ -60,9 +60,11 @@ valid_metrics: ["EOLE-XCOMET"]
 comet_batch_size: 64
 ```
 
-`EOLE-XCOMET` is reference-based and reports the scalar xCOMET score as a
-validation metric. Native prediction can compute xCOMET span metadata internally;
-the validation metric interface currently emits only the scalar score.
+`EOLE-XCOMET` is reference-optional and reports the scalar xCOMET score as a
+validation metric. When references are present, it uses source+hypothesis+reference
+scoring; without references, it falls back to source+hypothesis scoring. Native
+prediction can compute xCOMET span metadata internally; the validation metric
+interface currently emits only the scalar score.
 
 Set `comet_model` only when you want to override the default hosted model, for
 example to pin a different hosted EOLE conversion or use a local conversion:
@@ -88,7 +90,7 @@ For `transformer_encoder_scorer` models, use:
 
 - `--src`: source sentences
 - `--tgt`: MT hypotheses
-- `--ref`: references (required only for reference-based models)
+- `--ref`: references (required only for reference-based models; optional for XCOMET)
 
 Reference-based COMET scoring:
 
@@ -113,7 +115,7 @@ eole predict \
   --with_score
 ```
 
-XCOMET score-only CLI output:
+XCOMET score-only CLI output with references:
 
 ```bash
 eole predict \
@@ -122,6 +124,17 @@ eole predict \
   --tgt /path/to/mt.txt \
   --ref /path/to/ref.txt \
   --output /path/to/xcomet-scores.txt \
+  --with_score
+```
+
+Omit `--ref` to run XCOMET in source+hypothesis mode:
+
+```bash
+eole predict \
+  --model_path eole-nlp/xcomet-xl-eole-fp16 \
+  --src /path/to/src.txt \
+  --tgt /path/to/mt.txt \
+  --output /path/to/xcomet-qe-scores.txt \
   --with_score
 ```
 


### PR DESCRIPTION
This pull request updates the handling of the XCOMET (EOLE-XCOMET) model to make reference input optional rather than required. It modifies both the implementation and documentation to reflect that XCOMET can operate in reference-free mode as well as with references, and adds/updates tests to ensure correct behavior in both scenarios.

**Key changes:**

**Reference requirement logic and implementation:**
- Changed the logic in `sync_family_fields` (`eole/config/models.py`) so that only `unified_metric` models require a reference when "ref" is in `input_segments`, and not `xcomet_metric` models.
- Updated the `EoleXCometScorer` class to set `expect_reference = None`, allowing for both reference-based and reference-free operation.
- Improved `_validate_family` in `eole_comet.py` to check for the presence or absence of references only if `expect_reference` is not `None`.

**Testing and validation:**
- Added and updated tests in `test_convert_comet.py`, `test_encoder_scorer.py`, and `test_eole_comet_scorer.py` to verify that XCOMET models do not require references by default, and that both reference-based and reference-free modes are supported. [[1]](diffhunk://#diff-7aeebe02f8104ec060faf803dbe9dc224f76a0a24a81416ab74c91de4d5605fbL6-R16) [[2]](diffhunk://#diff-7aeebe02f8104ec060faf803dbe9dc224f76a0a24a81416ab74c91de4d5605fbR40-R58) [[3]](diffhunk://#diff-c9a8a753635fd633d85317d342f23e9ec3ec68e24a0fc73a439a46527e90cdc9L290-R297) [[4]](diffhunk://#diff-d90eba136cac608b198632d7b9d6febf60db61d049fb148228d3e361a89302c1L11-R23) [[5]](diffhunk://#diff-d90eba136cac608b198632d7b9d6febf60db61d049fb148228d3e361a89302c1R218-R235)

**Documentation updates:**
- Updated documentation in `recipes/scoring/README.md` and `recipes/scoring/comet_native/README.md` to describe EOLE-XCOMET as "reference-optional", clarify usage instructions, and provide CLI examples for both modes. [[1]](diffhunk://#diff-f1a0edc06b4fa80f6d87c39823c5533b78dfdc77794e81a891698a54a6aa734fL20-R20) [[2]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cL8-R8) [[3]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cL26-R26) [[4]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cL63-R67) [[5]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cL91-R93) [[6]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cL116-R118) [[7]](diffhunk://#diff-43cb801582b08a7331422a74eefaeebae87ddec93da97dd7f38e3d19df6e217cR130-R140)