### PR TITLE
Add new Chat Transform for dataset-level prompt formatting

### DIFF
--- a/docs/docusaurus_tsx/docs/concepts/config.md
+++ b/docs/docusaurus_tsx/docs/concepts/config.md
@@ -107,11 +107,18 @@ Supported URI forms are:
 
 When using HF streaming, `path_tgt` and `path_sco` must point to the same dataset, config, and split as `path_src`; only the final field name may differ.
 
+Use `additional_fields` to copy extra HF columns into each example before transforms run. This is useful when a transform prompt needs metadata such as WMT24++ `domain`, `document_id`, or `segment_id`.
+
 ```yaml
 data:
     gsm8k:
         path_src: hf://skrishna/gsm8k_only_answer/train/text
         path_tgt: hf://skrishna/gsm8k_only_answer/train/label
+        transforms: [chat, huggingface_tokenize]
+    wmt24pp-de:
+        path_src: hf://google/wmt24pp/en-de_DE/source
+        path_tgt: hf://google/wmt24pp/en-de_DE/target
+        additional_fields: [domain, document_id, segment_id]
         transforms: [chat, huggingface_tokenize]
     estimator:
         path_src: hf://eole-nlp/estimator_chatml/1720_da/prompt
@@ -120,6 +127,8 @@ data:
 ```
 
 Compact URIs treat common split names such as `train`, `valid`, `validation`, and `test` as splits. If a dataset config is literally named like a split, use the explicit four-part form: `hf://owner/dataset/config/split/field`.
+
+Missing configured `additional_fields` fail fast when the HF stream is read. `additional_fields` is currently supported only for HF streaming corpora.
 
 ## Dataset-Level Transform Overrides
 
@@ -142,6 +151,7 @@ data:
     wmt24pp-de:
         path_src: hf://google/wmt24pp/en-de_DE/source
         path_tgt: hf://google/wmt24pp/en-de_DE/target
+        additional_fields: [domain, document_id]
         transforms: [chat, huggingface_tokenize]
         transforms_configs:
             chat:
@@ -149,7 +159,7 @@ data:
                   - role: system
                     content: "You are a professional translator."
                   - role: user
-                    content: "Translate from English into German.\n\nEnglish: {src}\nGerman:"
+                    content: "Translate from English into German.\nDomain: {domain}\nDocument: {document_id}\n\nEnglish: {src}\nGerman:"
 
     wmt24pp-fr:
         path_src: hf://google/wmt24pp/en-fr_FR/source

--- a/docs/docusaurus_tsx/docs/concepts/config.md
+++ b/docs/docusaurus_tsx/docs/concepts/config.md
@@ -145,7 +145,6 @@ transforms_configs:
             content: "{src}"
     huggingface_tokenize:
         path: /Users/david/Development/Models/eole/eurollm-1.7B/tokenizer.json
-        max_length: 128
 
 data:
     wmt24pp-de:
@@ -174,6 +173,6 @@ data:
                     content: "Translate from English into French for Canada. Preserve names, numbers, and formatting.\n\nEnglish: {src}\nFrench:"
 ```
 
-Dataset-level overrides are intentionally scoped. Apply-time prompt settings such as `chat.messages` can vary by corpus. Warm-up settings such as `huggingface_tokenize.path`, `huggingface_tokenize.max_length`, BPE models, or SentencePiece models are global for the transform instance and cannot be overridden per dataset yet. Unsupported dataset-level transform overrides fail during config validation instead of being silently ignored.
+Dataset-level overrides are intentionally scoped. Apply-time prompt settings such as `chat.messages` can vary by corpus. Warm-up settings such as `huggingface_tokenize.path`, BPE models, or SentencePiece models are global for the transform instance and cannot be overridden per dataset yet. Unsupported dataset-level transform overrides fail during config validation instead of being silently ignored.
 
 If every corpus using `chat` supplies its own `transforms_configs.chat.messages`, the global `transforms_configs.chat.messages` may be empty. Any chat corpus without a dataset-level `messages` override needs global messages as a fallback. Overrides for transforms that are not enabled in the corpus `transforms` list fail during config validation.

--- a/docs/docusaurus_tsx/docs/concepts/config.md
+++ b/docs/docusaurus_tsx/docs/concepts/config.md
@@ -85,3 +85,85 @@ training:
     train_steps: 50
     valid_steps: 500
 ```
+
+## Hugging Face Streaming Datasets
+
+Datasets can stream directly from Hugging Face with `hf://` paths. The last path component is the dataset column to read.
+
+```yaml
+data:
+    corpus_1:
+        path_src: hf://eole-nlp/europarl-v10.de-en/de
+        path_tgt: hf://eole-nlp/europarl-v10.de-en/en
+        path_sco: hf://eole-nlp/europarl-v10.de-en/sco
+```
+
+Supported URI forms are:
+
+- `hf://owner/dataset/field` for the default `train` split.
+- `hf://owner/dataset/split/field` for an explicit split.
+- `hf://owner/dataset/config/field` for a dataset config with the default `train` split.
+- `hf://owner/dataset/config/split/field` for an explicit config and split.
+
+When using HF streaming, `path_tgt` and `path_sco` must point to the same dataset, config, and split as `path_src`; only the final field name may differ.
+
+```yaml
+data:
+    gsm8k:
+        path_src: hf://skrishna/gsm8k_only_answer/train/text
+        path_tgt: hf://skrishna/gsm8k_only_answer/train/label
+        transforms: [chat, huggingface_tokenize]
+    estimator:
+        path_src: hf://eole-nlp/estimator_chatml/1720_da/prompt
+        path_sco: hf://eole-nlp/estimator_chatml/1720_da/sco
+        transforms: [huggingface_tokenize]
+```
+
+Compact URIs treat common split names such as `train`, `valid`, `validation`, and `test` as splits. If a dataset config is literally named like a split, use the explicit four-part form: `hf://owner/dataset/config/split/field`.
+
+## Dataset-Level Transform Overrides
+
+Some transforms can opt in to dataset-level overrides via a corpus-local `transforms_configs` block. This is currently supported by the `chat` transform, which lets each corpus use a different prompt while sharing the same transform pipeline.
+
+```yaml
+transforms: [chat, huggingface_tokenize]
+
+transforms_configs:
+    chat:
+        add_generation_prompt: true
+        messages:
+          - role: user
+            content: "{src}"
+    huggingface_tokenize:
+        path: /Users/david/Development/Models/eole/eurollm-1.7B/tokenizer.json
+        max_length: 128
+
+data:
+    wmt24pp-de:
+        path_src: hf://google/wmt24pp/en-de_DE/source
+        path_tgt: hf://google/wmt24pp/en-de_DE/target
+        transforms: [chat, huggingface_tokenize]
+        transforms_configs:
+            chat:
+                messages:
+                  - role: system
+                    content: "You are a professional translator."
+                  - role: user
+                    content: "Translate from English into German.\n\nEnglish: {src}\nGerman:"
+
+    wmt24pp-fr:
+        path_src: hf://google/wmt24pp/en-fr_FR/source
+        path_tgt: hf://google/wmt24pp/en-fr_FR/target
+        transforms: [chat, huggingface_tokenize]
+        transforms_configs:
+            chat:
+                messages:
+                  - role: system
+                    content: "You are a careful localization translator for Canadian French."
+                  - role: user
+                    content: "Translate from English into French for Canada. Preserve names, numbers, and formatting.\n\nEnglish: {src}\nFrench:"
+```
+
+Dataset-level overrides are intentionally scoped. Apply-time prompt settings such as `chat.messages` can vary by corpus. Warm-up settings such as `huggingface_tokenize.path`, `huggingface_tokenize.max_length`, BPE models, or SentencePiece models are global for the transform instance and cannot be overridden per dataset yet. Unsupported dataset-level transform overrides fail during config validation instead of being silently ignored.
+
+If every corpus using `chat` supplies its own `transforms_configs.chat.messages`, the global `transforms_configs.chat.messages` may be empty. Any chat corpus without a dataset-level `messages` override needs global messages as a fallback. Overrides for transforms that are not enabled in the corpus `transforms` list fail during config validation.

--- a/docs/docusaurus_tsx/docs/concepts/transforms.md
+++ b/docs/docusaurus_tsx/docs/concepts/transforms.md
@@ -192,6 +192,7 @@ data:
   wmt24pp-de:
     path_src: hf://google/wmt24pp/en-de_DE/source
     path_tgt: hf://google/wmt24pp/en-de_DE/target
+    additional_fields: [domain, document_id]
     transforms: [chat, huggingface_tokenize]
     transforms_configs:
       chat:
@@ -199,7 +200,7 @@ data:
           - role: system
             content: "You are a professional translator."
           - role: user
-            content: "Translate from English into German.\n\nEnglish: {src}\nGerman:"
+            content: "Translate from English into German.\nDomain: {domain}\nDocument: {document_id}\n\nEnglish: {src}\nGerman:"
 
   wmt24pp-fr:
     path_src: hf://google/wmt24pp/en-fr_FR/source
@@ -225,6 +226,8 @@ Dataset-level `chat` overrides use shallow per-key replacement:
 | omitted keys | Inherit from global `transforms_configs.chat` |
 
 Only `chat` currently supports dataset-level overrides. Tokenizer warm-up settings such as `huggingface_tokenize.path` and `huggingface_tokenize.max_length` are global for the transform instance and cannot vary per dataset yet.
+
+For HF streaming corpora, dataset `additional_fields` are available to `chat.messages` with the same `{field}` syntax as `{src}` and `{tgt}`. Missing configured additional fields fail when the stream is read.
 
 When configured, `huggingface_tokenize.max_length` truncates encoded token IDs and token strings after rendering. If truncation cuts a target sequence, any EOS token beyond the limit is dropped with the rest of the truncated suffix.
 

--- a/docs/docusaurus_tsx/docs/concepts/transforms.md
+++ b/docs/docusaurus_tsx/docs/concepts/transforms.md
@@ -225,11 +225,9 @@ Dataset-level `chat` overrides use shallow per-key replacement:
 | `target` | Replaces global dict |
 | omitted keys | Inherit from global `transforms_configs.chat` |
 
-Only `chat` currently supports dataset-level overrides. Tokenizer warm-up settings such as `huggingface_tokenize.path` and `huggingface_tokenize.max_length` are global for the transform instance and cannot vary per dataset yet.
+Only `chat` currently supports dataset-level overrides. Tokenizer warm-up settings such as `huggingface_tokenize.path` are global for the transform instance and cannot vary per dataset yet.
 
 For HF streaming corpora, dataset `additional_fields` are available to `chat.messages` with the same `{field}` syntax as `{src}` and `{tgt}`. Missing configured additional fields fail when the stream is read.
-
-When configured, `huggingface_tokenize.max_length` truncates encoded token IDs and token strings after rendering. If truncation cuts a target sequence, any EOS token beyond the limit is dropped with the rest of the truncated suffix.
 
 
 #### Augment source segments with fuzzy matches for Neural Fuzzy Repair

--- a/docs/docusaurus_tsx/docs/concepts/transforms.md
+++ b/docs/docusaurus_tsx/docs/concepts/transforms.md
@@ -148,6 +148,87 @@ When working with several workers, this require some precaution in order to make
 Example: `max_context=1` and 1 GPU, then num_workers must be 2 or 4.
 
 
+#### Render chat prompts
+
+Transform name: `chat`
+
+Class: `eole.transforms.chat.ChatTransform`
+
+Renders one or more configured messages with the converted model's `inference.chat_template`. This is useful for instruction-tuning or chat-style datasets where the source field contains a question, instruction, or other raw fields that need to be wrapped in the model's chat format.
+
+Use `chat` before an id-tokenizing transform such as `huggingface_tokenize`:
+
+```yaml
+transforms: [chat, huggingface_tokenize]
+transforms_configs:
+  chat:
+    add_generation_prompt: true
+    messages:
+      - role: user
+        content: "Solve this problem.\n\n{src}"
+  huggingface_tokenize:
+    path: ${EOLE_MODEL_DIR}/qwen3-0.6B/tokenizer.json
+
+data:
+  corpus_1:
+    path_src: hf://skrishna/gsm8k_only_answer/train/text
+    path_tgt: hf://skrishna/gsm8k_only_answer/train/label
+    transforms: [chat, huggingface_tokenize]
+```
+
+Message values are formatted with Python `str.format` against the example fields, so `{src}` inserts the source field and `{tgt}` inserts the target field when present. Escape literal braces as `{{` and `}}`.
+
+Options:
+
+- `messages`: list of chat messages to render. Each message is usually a mapping with `role` and `content`.
+- `add_generation_prompt`: whether to ask the template to append the assistant generation prefix.
+- `chat_template_kwargs`: extra variables passed to the chat template, such as `enable_thinking: false` for templates that support it.
+- `target.strip_commas`: remove commas from `tgt` and `raw_tgt`, useful for numeric answer datasets.
+
+The `chat` transform also supports dataset-level overrides in each corpus's `transforms_configs.chat` block. This lets one training run use different prompts for different datasets or language pairs.
+
+```yaml
+data:
+  wmt24pp-de:
+    path_src: hf://google/wmt24pp/en-de_DE/source
+    path_tgt: hf://google/wmt24pp/en-de_DE/target
+    transforms: [chat, huggingface_tokenize]
+    transforms_configs:
+      chat:
+        messages:
+          - role: system
+            content: "You are a professional translator."
+          - role: user
+            content: "Translate from English into German.\n\nEnglish: {src}\nGerman:"
+
+  wmt24pp-fr:
+    path_src: hf://google/wmt24pp/en-fr_FR/source
+    path_tgt: hf://google/wmt24pp/en-fr_FR/target
+    transforms: [chat, huggingface_tokenize]
+    transforms_configs:
+      chat:
+        messages:
+          - role: system
+            content: "You are a careful localization translator for Canadian French."
+          - role: user
+            content: "Translate from English into French for Canada.\n\nEnglish: {src}\nFrench:"
+```
+
+Dataset-level `chat` overrides use shallow per-key replacement:
+
+| Key | Override behavior |
+| --- | --- |
+| `messages` | Replaces global `messages` wholesale |
+| `add_generation_prompt` | Replaces global value |
+| `chat_template_kwargs` | Replaces global dict |
+| `target` | Replaces global dict |
+| omitted keys | Inherit from global `transforms_configs.chat` |
+
+Only `chat` currently supports dataset-level overrides. Tokenizer warm-up settings such as `huggingface_tokenize.path` and `huggingface_tokenize.max_length` are global for the transform instance and cannot vary per dataset yet.
+
+When configured, `huggingface_tokenize.max_length` truncates encoded token IDs and token strings after rendering. If truncation cuts a target sequence, any EOS token beyond the limit is dropped with the rest of the truncated suffix.
+
+
 #### Augment source segments with fuzzy matches for Neural Fuzzy Repair
 
 Transform name: `fuzzymatch`

--- a/eole/config/data.py
+++ b/eole/config/data.py
@@ -72,6 +72,7 @@ class Dataset(Config):
     path_sco: str | None = None
     path_txt: str | None = None  # not sure we need this one with proper path_src handling
     path_align: str | None = None
+    additional_fields: List[str] | None = None
     transforms_configs: Dict[str, Dict[str, Any]] | None = None
     # optional stuff for some transforms
     # TODO: define a better mechanism to support such settings
@@ -97,6 +98,18 @@ class Dataset(Config):
     avg_tok_min: float | None = 3
     avg_tok_max: float | None = 20
     lang_id: List[str] | None = ["en", "fr"]
+
+    @field_validator("additional_fields")
+    @classmethod
+    def _reject_reserved_additional_fields(cls, v):
+        if v is None:
+            return v
+        reserved_fields = {"src", "tgt", "sco", "align"}
+        reserved_additional_fields = sorted(reserved_fields.intersection(v))
+        if reserved_additional_fields:
+            fields = ", ".join(reserved_additional_fields)
+            raise ValueError(f"additional_fields cannot use reserved example fields: {fields}.")
+        return v
 
 
 # add all opts from all transforms (like in eole.opts._add_transform_opt)

--- a/eole/config/data.py
+++ b/eole/config/data.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Literal
+from typing import Any, Dict, List, Literal
 from pydantic import Field, field_validator, model_validator
 from pydantic import create_model
 
@@ -72,6 +72,7 @@ class Dataset(Config):
     path_sco: str | None = None
     path_txt: str | None = None  # not sure we need this one with proper path_src handling
     path_align: str | None = None
+    transforms_configs: Dict[str, Dict[str, Any]] | None = None
     # optional stuff for some transforms
     # TODO: define a better mechanism to support such settings
     src_prefix: str | None = None
@@ -231,6 +232,21 @@ class DataConfig(VocabConfig):  # , AllTransformsConfig):
             if _transforms is None:
                 logger.info(f"Missing transforms field for {cname} data, " f"set to default: {default_transforms}.")
                 corpus.transforms = default_transforms
+            if corpus.transforms_configs is not None:
+                for transform_name in corpus.transforms_configs:
+                    transform_cls = AVAILABLE_TRANSFORMS.get(transform_name)
+                    if transform_cls is None:
+                        raise ValueError(f"Corpus {cname} overrides unknown transform: {transform_name}.")
+                    if transform_name not in (corpus.transforms or []):
+                        raise ValueError(
+                            f"Corpus {cname} overrides transform {transform_name}, but {transform_name} is not enabled "
+                            f"in corpus transforms."
+                        )
+                    if not getattr(transform_cls, "supports_dataset_overrides", False):
+                        raise ValueError(
+                            f"Corpus {cname} overrides transform {transform_name}, but dataset-level overrides "
+                            f"are not supported for this transform."
+                        )
             # Check path
             if corpus.path_src is None and corpus.path_txt is None:
                 raise ValueError(

--- a/eole/inputters/text_corpus.py
+++ b/eole/inputters/text_corpus.py
@@ -150,6 +150,75 @@ class ParallelCorpus(object):
         self.sco = path_sco
         self.align = path_align
 
+    @staticmethod
+    def _parse_hf_dataset_uri(hf_string):
+        """Parse hf://owner/dataset[/config][/split]/field dataset references."""
+        parts = hf_string.replace("hf://", "", 1).split("/")
+        if len(parts) < 3:
+            raise ValueError(
+                f"Invalid Hugging Face dataset reference: {hf_string!r}. "
+                "Expected hf://owner/dataset/field or hf://owner/dataset/split/field."
+            )
+
+        dataset_name = "/".join(parts[:2])
+        remaining_parts = parts[2:]
+        field_name = remaining_parts[-1]
+        dataset_config = None
+        split = "train"
+
+        def normalize_split(value):
+            if value == "valid":
+                return "validation"
+            if value.startswith("valid["):
+                suffix = value.removeprefix("valid")
+                return "validation" + suffix
+            return value
+
+        if len(remaining_parts) == 2:
+            first = remaining_parts[0]
+            # Heuristic for the compact slash syntax: common split names in the third
+            # position are treated as splits; other values are treated as dataset configs.
+            # Ambiguous configs named train/test/validation should use the explicit
+            # hf://owner/dataset/config/split/field form.
+            if first in {"train", "validation", "valid", "test"} or first.startswith(
+                ("train[", "validation[", "valid[", "test[")
+            ):
+                split = normalize_split(first)
+            else:
+                dataset_config = first
+        elif len(remaining_parts) == 3:
+            dataset_config = remaining_parts[0]
+            split = normalize_split(remaining_parts[1])
+        elif len(remaining_parts) > 3:
+            raise ValueError(
+                f"Invalid Hugging Face dataset reference: {hf_string!r}. "
+                "Expected hf://owner/dataset/field, hf://owner/dataset/split/field, "
+                "or hf://owner/dataset/config/split/field."
+            )
+
+        return dataset_name, dataset_config, split, field_name
+
+    @classmethod
+    def _parse_matching_hf_field(cls, hf_string, src_info, field_name):
+        if hf_string is None:
+            return None
+        if not isinstance(hf_string, str) or not hf_string.startswith("hf://"):
+            raise ValueError(
+                f"HF streaming corpora require {field_name} to use the same hf:// dataset/config/split as path_src."
+            )
+        info = cls._parse_hf_dataset_uri(hf_string)
+        if info[:3] != src_info[:3]:
+            raise ValueError(
+                f"HF streaming corpora require {field_name} to use the same hf:// dataset/config/split as path_src."
+            )
+        return info[3]
+
+    @staticmethod
+    def _get_hf_field(example, field_name, uri_field_name):
+        if field_name not in example:
+            raise ValueError(f"HF streaming example is missing configured {uri_field_name} field: {field_name!r}.")
+        return example[field_name]
+
     def _load_hf_dataset(self, hf_string):
         """
         Load a Hugging Face dataset from the given identifier.
@@ -159,14 +228,10 @@ class ParallelCorpus(object):
         """
         from datasets import load_dataset
 
-        parts = hf_string.replace("hf://", "").split("/")
-        dataset_name = "/".join(parts[:2])
-        remaining_parts = parts[2:]
-
-        if len(remaining_parts) == 1:
-            return load_dataset(dataset_name, split="train", streaming=True)
-        elif len(remaining_parts) == 2:
-            return load_dataset(dataset_name, remaining_parts[0], split="train", streaming=True)
+        dataset_name, dataset_config, split, _field_name = self._parse_hf_dataset_uri(hf_string)
+        if dataset_config is None:
+            return load_dataset(dataset_name, split=split, streaming=True)
+        return load_dataset(dataset_name, dataset_config, split=split, streaming=True)
 
     def load(self, offset=0, stride=1):
         """
@@ -175,9 +240,7 @@ class ParallelCorpus(object):
         `stride` example, starting from `offset`.
         In the case of local files, all files are open exactly the same way by each worker
         Therefore we need to apply a stride / offset rule to make sure we do not process the same ex.
-        In the case of HF streaming mode we need to make sure we have more shards than workers.
-        Typically we recommend to have shard being a multiple of workers for instance for big datasets:
-        16 shards for 4 workers. The shards will be iterated automatically since HF locks shards when in use.
+        HF streaming uses the same rule because each worker/rank opens an independent streaming iterator.
         """
 
         def make_ex(sline, tline, scoline, align):
@@ -203,15 +266,17 @@ class ParallelCorpus(object):
 
         elif self.src.startswith("hf://"):
             # If `src` is a Hugging Face dataset identifier
+            src_info = self._parse_hf_dataset_uri(self.src)
+            src_field = src_info[3]
+            tgt_field = self._parse_matching_hf_field(self.tgt, src_info, "path_tgt")
+            sco_field = self._parse_matching_hf_field(self.sco, src_info, "path_sco")
             dataset = self._load_hf_dataset(self.src)
             for i, example in enumerate(dataset):
-                sline = example.get(self.src.split("/")[-1])
-                tline = example.get(self.tgt.split("/")[-1]) if self.tgt is not None else None
-                if self.sco is not None:
-                    scoline = example.get(self.sco.split("/")[-1], 1.0)
-                else:
-                    scoline = 1.0
-                yield make_ex(sline, tline, scoline, None)
+                if (i // stride) % stride == offset:
+                    sline = self._get_hf_field(example, src_field, "path_src")
+                    tline = self._get_hf_field(example, tgt_field, "path_tgt") if tgt_field is not None else None
+                    scoline = self._get_hf_field(example, sco_field, "path_sco") if sco_field is not None else 1.0
+                    yield make_ex(sline, tline, scoline, None)
 
         else:
             with exfile_open(self.src, mode="rb") as fs, exfile_open(self.tgt, mode="rb") as ft, exfile_open(

--- a/eole/inputters/text_corpus.py
+++ b/eole/inputters/text_corpus.py
@@ -142,13 +142,14 @@ class ImageTextCorpus(object):
 class ParallelCorpus(object):
     """A parallel corpus file pair that can be loaded to iterate."""
 
-    def __init__(self, name, path_src, path_tgt, path_sco=None, path_align=None):
+    def __init__(self, name, path_src, path_tgt, path_sco=None, path_align=None, additional_fields=None):
         """Initialize src & tgt side file path."""
         self.id = name
         self.src = path_src
         self.tgt = path_tgt
         self.sco = path_sco
         self.align = path_align
+        self.additional_fields = additional_fields or []
 
     @staticmethod
     def _parse_hf_dataset_uri(hf_string):
@@ -242,8 +243,10 @@ class ParallelCorpus(object):
         Therefore we need to apply a stride / offset rule to make sure we do not process the same ex.
         HF streaming uses the same rule because each worker/rank opens an independent streaming iterator.
         """
+        if self.additional_fields and not (isinstance(self.src, str) and self.src.startswith("hf://")):
+            raise ValueError("additional_fields is currently supported only for HF streaming corpora.")
 
-        def make_ex(sline, tline, scoline, align):
+        def make_ex(sline, tline, scoline, align, additional_values=None):
             example = {
                 "src": sline,
                 "tgt": tline,
@@ -251,6 +254,8 @@ class ParallelCorpus(object):
             }
             if align is not None:
                 example["align"] = align
+            if additional_values is not None:
+                example.update(additional_values)
             return example
 
         if isinstance(self.src, list):
@@ -276,7 +281,11 @@ class ParallelCorpus(object):
                     sline = self._get_hf_field(example, src_field, "path_src")
                     tline = self._get_hf_field(example, tgt_field, "path_tgt") if tgt_field is not None else None
                     scoline = self._get_hf_field(example, sco_field, "path_sco") if sco_field is not None else 1.0
-                    yield make_ex(sline, tline, scoline, None)
+                    additional_values = {
+                        field: self._get_hf_field(example, field, "additional_fields")
+                        for field in self.additional_fields
+                    }
+                    yield make_ex(sline, tline, scoline, None, additional_values)
 
         else:
             with exfile_open(self.src, mode="rb") as fs, exfile_open(self.tgt, mode="rb") as ft, exfile_open(
@@ -312,6 +321,7 @@ def get_corpora(config, task=CorpusTask.TRAIN, src=None, tgt=None, align=None):
                         corpus_dict.path_tgt,
                         corpus_dict.path_sco,
                         corpus_dict.path_align,
+                        corpus_dict.additional_fields,
                     )
                 elif data_type == "text":
                     corpora_dict[corpus_id] = BlockwiseCorpus(
@@ -341,6 +351,7 @@ def get_corpora(config, task=CorpusTask.TRAIN, src=None, tgt=None, align=None):
                     config.data[CorpusName.VALID].path_tgt,
                     None,
                     config.data[CorpusName.VALID].path_align,
+                    config.data[CorpusName.VALID].additional_fields,
                 )
             elif data_type == "image":
                 corpora_dict[CorpusName.VALID] = ImageTextCorpus(

--- a/eole/tests/test_transform.py
+++ b/eole/tests/test_transform.py
@@ -20,18 +20,6 @@ from eole.config.run import TrainConfig, PredictConfig
 from eole.config.data import Dataset
 from eole.config.models import CustomModelConfig
 from eole.inputters.text_corpus import ParallelCorpus
-from eole.transforms.tokenize_id import HuggingfaceTokenizer
-
-
-class _FakeHFEncoding:
-    def __init__(self, tokens):
-        self.ids = list(range(len(tokens)))
-        self.tokens = tokens
-
-
-class _FakeHFTokenizer:
-    def encode(self, text):
-        return _FakeHFEncoding(text.split())
 
 
 class TestTransform(unittest.TestCase):
@@ -226,39 +214,6 @@ class TestTransform(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "additional_fields.*HF streaming"):
             list(corpus.load())
-
-    def test_huggingface_tokenize_max_length_truncates_ids_and_tokens(self):
-        transform = object.__new__(HuggingfaceTokenizer)
-        transform.tokenizer = _FakeHFTokenizer()
-        transform.max_length = 3
-        transform.full_config = Namespace(decoder_start_token="<s>", model=Namespace(encoder=object()))
-
-        ids, tokens = transform.tokenize_string("a b c d", side="src")
-
-        self.assertEqual(ids, [0, 1, 2])
-        self.assertEqual(tokens, ["a", "b", "c"])
-
-    def test_huggingface_tokenize_without_max_length_keeps_full_encoding(self):
-        transform = object.__new__(HuggingfaceTokenizer)
-        transform.tokenizer = _FakeHFTokenizer()
-        transform.max_length = None
-        transform.full_config = Namespace(decoder_start_token="<s>", model=Namespace(encoder=object()))
-
-        ids, tokens = transform.tokenize_string("a b c d", side="src")
-
-        self.assertEqual(ids, [0, 1, 2, 3])
-        self.assertEqual(tokens, ["a", "b", "c", "d"])
-
-    def test_huggingface_tokenize_decoder_only_empty_start_target_keeps_extra_token(self):
-        transform = object.__new__(HuggingfaceTokenizer)
-        transform.tokenizer = _FakeHFTokenizer()
-        transform.max_length = 3
-        transform.full_config = Namespace(decoder_start_token="", model=Namespace(encoder=None))
-
-        ids, tokens = transform.tokenize_string("a b c d", side="tgt")
-
-        self.assertEqual(ids, [0, 1, 2, 3])
-        self.assertEqual(tokens, ["a", "b", "c", "d"])
 
     def test_chat_transform_renders_messages_with_eole_chat_template(self):
         transforms_cls = get_transforms_cls(["chat"])

--- a/eole/tests/test_transform.py
+++ b/eole/tests/test_transform.py
@@ -7,6 +7,7 @@ import random
 import yaml
 import math
 from argparse import Namespace
+from unittest.mock import patch
 from eole.transforms import (
     get_transforms_cls,
     get_specials,
@@ -18,6 +19,19 @@ from eole.transforms.normalize import MosesPunctNormalizer
 from eole.config.run import TrainConfig, PredictConfig
 from eole.config.data import Dataset
 from eole.config.models import CustomModelConfig
+from eole.inputters.text_corpus import ParallelCorpus
+from eole.transforms.tokenize_id import HuggingfaceTokenizer
+
+
+class _FakeHFEncoding:
+    def __init__(self, tokens):
+        self.ids = list(range(len(tokens)))
+        self.tokens = tokens
+
+
+class _FakeHFTokenizer:
+    def encode(self, text):
+        return _FakeHFEncoding(text.split())
 
 
 class TestTransform(unittest.TestCase):
@@ -53,6 +67,427 @@ class TestTransform(unittest.TestCase):
         with self.assertRaises(ValueError):
             transforms_cls["switchout"](opt).warm_up(vocabs=None)
             transforms_cls["bart"](opt).warm_up(vocabs=None)
+
+    def test_hf_dataset_uri_parser_supports_split_and_field(self):
+        dataset_name, dataset_config, split, field = ParallelCorpus._parse_hf_dataset_uri(
+            "hf://skrishna/gsm8k_only_answer/test/label"
+        )
+
+        self.assertEqual(dataset_name, "skrishna/gsm8k_only_answer")
+        self.assertIsNone(dataset_config)
+        self.assertEqual(split, "test")
+        self.assertEqual(field, "label")
+
+    def test_hf_dataset_uri_parser_supports_config_and_default_train_split(self):
+        dataset_name, dataset_config, split, field = ParallelCorpus._parse_hf_dataset_uri(
+            "hf://eole-nlp/estimator_chatml/1720_da/prompt"
+        )
+
+        self.assertEqual(dataset_name, "eole-nlp/estimator_chatml")
+        self.assertEqual(dataset_config, "1720_da")
+        self.assertEqual(split, "train")
+        self.assertEqual(field, "prompt")
+
+    def test_hf_dataset_uri_parser_maps_valid_slice_to_validation_slice(self):
+        self.assertEqual(
+            ParallelCorpus._parse_hf_dataset_uri("hf://owner/name/valid[:100]/text"),
+            ("owner/name", None, "validation[:100]", "text"),
+        )
+
+    def test_hf_streaming_rejects_mixed_local_target(self):
+        corpus = ParallelCorpus("train", "hf://owner/name/train/text", "target.txt")
+
+        with self.assertRaisesRegex(ValueError, "path_tgt.*same hf:// dataset/config/split"):
+            list(corpus.load())
+
+    def test_hf_streaming_rejects_mismatched_target_split(self):
+        corpus = ParallelCorpus("train", "hf://owner/name/train/text", "hf://owner/name/test/label")
+
+        with self.assertRaisesRegex(ValueError, "path_tgt.*same hf:// dataset/config/split"):
+            list(corpus.load())
+
+    def test_hf_streaming_loads_gsm8k_split_fields(self):
+        corpus = ParallelCorpus(
+            "train",
+            "hf://skrishna/gsm8k_only_answer/train/text",
+            "hf://skrishna/gsm8k_only_answer/train/label",
+        )
+        rows = [
+            {"text": "question 1", "label": "answer 1"},
+            {"text": "question 2", "label": "answer 2"},
+        ]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            examples = list(corpus.load())
+
+        self.assertEqual(examples[0]["src"], "question 1")
+        self.assertEqual(examples[0]["tgt"], "answer 1")
+        self.assertEqual(examples[0]["sco"], 1.0)
+        self.assertEqual(examples[1]["src"], "question 2")
+        self.assertEqual(examples[1]["tgt"], "answer 2")
+
+    def test_hf_streaming_loads_estimator_config_fields(self):
+        corpus = ParallelCorpus(
+            "train",
+            "hf://eole-nlp/estimator_chatml/1720_da/prompt",
+            None,
+            "hf://eole-nlp/estimator_chatml/1720_da/sco",
+        )
+        rows = [
+            {"prompt": "prompt 1", "sco": 0.5},
+            {"prompt": "prompt 2", "sco": 0.75},
+        ]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            examples = list(corpus.load())
+
+        self.assertEqual(examples[0]["src"], "prompt 1")
+        self.assertIsNone(examples[0]["tgt"])
+        self.assertEqual(examples[0]["sco"], 0.5)
+        self.assertEqual(examples[1]["src"], "prompt 2")
+        self.assertEqual(examples[1]["sco"], 0.75)
+
+    def test_hf_streaming_applies_offset_and_stride(self):
+        corpus = ParallelCorpus("train", "hf://owner/name/train/text", None)
+        rows = [{"text": "zero"}, {"text": "one"}, {"text": "two"}, {"text": "three"}]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            examples = list(corpus.load(offset=1, stride=2))
+
+        self.assertEqual([example["src"] for example in examples], ["two", "three"])
+
+    def test_hf_streaming_rejects_missing_configured_field(self):
+        corpus = ParallelCorpus("train", "hf://owner/name/train/text", "hf://owner/name/train/label")
+        rows = [{"text": "question"}]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            with self.assertRaisesRegex(ValueError, "path_tgt field: 'label'"):
+                list(corpus.load())
+
+    def test_huggingface_tokenize_max_length_truncates_ids_and_tokens(self):
+        transform = object.__new__(HuggingfaceTokenizer)
+        transform.tokenizer = _FakeHFTokenizer()
+        transform.max_length = 3
+        transform.full_config = Namespace(decoder_start_token="<s>", model=Namespace(encoder=object()))
+
+        ids, tokens = transform.tokenize_string("a b c d", side="src")
+
+        self.assertEqual(ids, [0, 1, 2])
+        self.assertEqual(tokens, ["a", "b", "c"])
+
+    def test_huggingface_tokenize_without_max_length_keeps_full_encoding(self):
+        transform = object.__new__(HuggingfaceTokenizer)
+        transform.tokenizer = _FakeHFTokenizer()
+        transform.max_length = None
+        transform.full_config = Namespace(decoder_start_token="<s>", model=Namespace(encoder=object()))
+
+        ids, tokens = transform.tokenize_string("a b c d", side="src")
+
+        self.assertEqual(ids, [0, 1, 2, 3])
+        self.assertEqual(tokens, ["a", "b", "c", "d"])
+
+    def test_huggingface_tokenize_decoder_only_empty_start_target_keeps_extra_token(self):
+        transform = object.__new__(HuggingfaceTokenizer)
+        transform.tokenizer = _FakeHFTokenizer()
+        transform.max_length = 3
+        transform.full_config = Namespace(decoder_start_token="", model=Namespace(encoder=None))
+
+        ids, tokens = transform.tokenize_string("a b c d", side="tgt")
+
+        self.assertEqual(ids, [0, 1, 2, 3])
+        self.assertEqual(tokens, ["a", "b", "c", "d"])
+
+    def test_chat_transform_renders_messages_with_eole_chat_template(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        chat_template = (
+            "{% for message in messages %}"
+            "<|im_start|>{{ message.role }}\n{{ message.content }}<|im_end|>\n"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+        )
+        opt = TrainConfig(
+            data={"dummy": Dataset(path_src="eole/tests/data/src-train.txt")},
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={
+                "chat": {
+                    "add_generation_prompt": True,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Respond in XML.\n\n{src}",
+                        }
+                    ],
+                    "target": {"strip_commas": True},
+                }
+            },
+            inference={"chat_template": chat_template},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        example = {
+            "src": "What is 1,000 + 5?",
+            "tgt": "1,005",
+            "raw_tgt": "1,005",
+        }
+        transformed = transform.apply(example)
+
+        self.assertEqual(
+            transformed["src"],
+            "<|im_start|>user\nRespond in XML.\n\nWhat is 1,000 + 5?<|im_end|>\n<|im_start|>assistant\n",
+        )
+        self.assertEqual(transformed["tgt"], "1005")
+        self.assertEqual(transformed["raw_tgt"], "1005")
+
+    def test_chat_transform_passes_special_tokens_and_template_kwargs(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        chat_template = "{{ bos_token }}{% if enable_thinking is false %}no-think:{% endif %}{{ messages[0].content }}"
+        opt = TrainConfig(
+            data={"dummy": Dataset(path_src="eole/tests/data/src-train.txt")},
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={
+                "chat": {
+                    "messages": [{"role": "user", "content": "{src}"}],
+                    "chat_template_kwargs": {"enable_thinking": False},
+                }
+            },
+            inference={"chat_template": chat_template},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up(vocabs={"specials": {"bos_token": "<s>"}})
+
+        transformed = transform.apply({"src": "hello"})
+
+        self.assertEqual(transformed["src"], "<s>no-think:hello")
+
+    def test_chat_transform_uses_dataset_message_override(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into German: {src}"}]}
+                    },
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": [{"role": "user", "content": "GLOBAL {src}"}]}},
+            inference={
+                "chat_template": "{{ messages[0].content }}{% if add_generation_prompt %}<assistant>{% endif %}"
+            },
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        transformed = transform.apply({"src": "Hello"}, corpus_name="de")
+
+        self.assertEqual(transformed["src"], "Translate into German: Hello<assistant>")
+
+    def test_chat_transform_uses_different_dataset_prompts(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into German: {src}"}]}
+                    },
+                ),
+                "fr": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into French: {src}"}]}
+                    },
+                ),
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": [{"role": "user", "content": "GLOBAL {src}"}]}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        de = transform.apply({"src": "Hello"}, corpus_name="de")
+        fr = transform.apply({"src": "Hello"}, corpus_name="fr")
+
+        self.assertEqual(de["src"], "Translate into German: Hello")
+        self.assertEqual(fr["src"], "Translate into French: Hello")
+
+    def test_chat_transform_dataset_override_inherits_omitted_global_keys(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into German: {src}"}]}
+                    },
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={
+                "chat": {
+                    "add_generation_prompt": False,
+                    "messages": [{"role": "user", "content": "GLOBAL {src}"}],
+                }
+            },
+            inference={
+                "chat_template": "{{ messages[0].content }}{% if add_generation_prompt %}<assistant>{% endif %}"
+            },
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        transformed = transform.apply({"src": "Hello"}, corpus_name="de")
+
+        self.assertEqual(transformed["src"], "Translate into German: Hello")
+
+    def test_chat_transform_unknown_corpus_falls_back_to_global_config(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={"de": Dataset(path_src="eole/tests/data/src-train.txt")},
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": [{"role": "user", "content": "GLOBAL {src}"}]}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        transformed = transform.apply({"src": "Hello"}, corpus_name="infer")
+
+        self.assertEqual(transformed["src"], "GLOBAL Hello")
+
+    def test_chat_transform_dataset_override_rejects_unknown_keys(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={"chat": {"add_generation_promt": False}},
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": [{"role": "user", "content": "GLOBAL {src}"}]}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+
+        with self.assertRaisesRegex(ValueError, "add_generation_promt"):
+            transform.warm_up()
+
+    def test_dataset_override_rejects_unsupported_transform(self):
+        with self.assertRaisesRegex(ValueError, "dataset-level overrides are not supported"):
+            TrainConfig(
+                data={
+                    "de": Dataset(
+                        path_src="eole/tests/data/src-train.txt",
+                        transforms=["huggingface_tokenize"],
+                        transforms_configs={"huggingface_tokenize": {"max_length": 64}},
+                    )
+                },
+                src_vocab="dummy",
+                share_vocab=True,
+                model=CustomModelConfig(),
+            )._validate_data_config()
+
+    def test_chat_transform_allows_empty_global_messages_when_all_chat_corpora_override(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into German: {src}"}]}
+                    },
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": []}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        transformed = transform.apply({"src": "Hello"}, corpus_name="de")
+
+        self.assertEqual(transformed["src"], "Translate into German: Hello")
+
+    def test_chat_transform_empty_global_messages_requires_override_for_each_chat_corpus(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={"de": Dataset(path_src="eole/tests/data/src-train.txt", transforms=["chat"])},
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": []}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+
+        with self.assertRaisesRegex(ValueError, "Missing messages for: de"):
+            transform.warm_up()
+
+    def test_chat_transform_unknown_corpus_with_empty_global_messages_errors(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="eole/tests/data/src-train.txt",
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {"messages": [{"role": "user", "content": "Translate into German: {src}"}]}
+                    },
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": []}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        with self.assertRaisesRegex(ValueError, "no messages for this corpus"):
+            transform.apply({"src": "Hello"}, corpus_name="infer")
+
+    def test_dataset_override_rejects_transform_not_enabled_for_corpus(self):
+        with self.assertRaisesRegex(ValueError, "chat is not enabled in corpus transforms"):
+            TrainConfig(
+                data={
+                    "de": Dataset(
+                        path_src="eole/tests/data/src-train.txt",
+                        transforms=["huggingface_tokenize"],
+                        transforms_configs={"chat": {"messages": [{"role": "user", "content": "{src}"}]}},
+                    )
+                },
+                src_vocab="dummy",
+                share_vocab=True,
+                model=CustomModelConfig(),
+            )._validate_data_config()
 
     def test_transform_specials(self):
         # This test is a bit broken.

--- a/eole/tests/test_transform.py
+++ b/eole/tests/test_transform.py
@@ -164,6 +164,69 @@ class TestTransform(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "path_tgt field: 'label'"):
                 list(corpus.load())
 
+    def test_hf_streaming_copies_additional_fields(self):
+        corpus = ParallelCorpus(
+            "train",
+            "hf://google/wmt24pp/en-de_DE/source",
+            "hf://google/wmt24pp/en-de_DE/target",
+            additional_fields=["domain", "document_id"],
+        )
+        rows = [
+            {
+                "source": "Hello",
+                "target": "Hallo",
+                "domain": "news",
+                "document_id": "doc-1",
+            }
+        ]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            examples = list(corpus.load())
+
+        self.assertEqual(examples[0]["src"], "Hello")
+        self.assertEqual(examples[0]["tgt"], "Hallo")
+        self.assertEqual(examples[0]["domain"], "news")
+        self.assertEqual(examples[0]["document_id"], "doc-1")
+
+    def test_hf_streaming_rejects_missing_additional_field(self):
+        corpus = ParallelCorpus(
+            "train",
+            "hf://google/wmt24pp/en-de_DE/source",
+            "hf://google/wmt24pp/en-de_DE/target",
+            additional_fields=["domain"],
+        )
+        rows = [{"source": "Hello", "target": "Hallo"}]
+
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            with self.assertRaisesRegex(ValueError, "additional_fields field: 'domain'"):
+                list(corpus.load())
+
+    def test_additional_fields_reject_reserved_example_fields(self):
+        with self.assertRaisesRegex(ValueError, "additional_fields.*reserved.*src"):
+            TrainConfig(
+                data={
+                    "wmt24pp-de": Dataset(
+                        path_src="hf://google/wmt24pp/en-de_DE/source",
+                        path_tgt="hf://google/wmt24pp/en-de_DE/target",
+                        additional_fields=["domain", "src"],
+                    )
+                },
+                src_vocab="dummy",
+                share_vocab=True,
+                model=CustomModelConfig(),
+            )
+
+    def test_local_corpus_rejects_additional_fields(self):
+        corpus = ParallelCorpus(
+            "train",
+            "eole/tests/data/src-train.txt",
+            "eole/tests/data/tgt-train.txt",
+            additional_fields=["domain"],
+        )
+
+        with self.assertRaisesRegex(ValueError, "additional_fields.*HF streaming"):
+            list(corpus.load())
+
     def test_huggingface_tokenize_max_length_truncates_ids_and_tokens(self):
         transform = object.__new__(HuggingfaceTokenizer)
         transform.tokenizer = _FakeHFTokenizer()
@@ -325,6 +388,57 @@ class TestTransform(unittest.TestCase):
         self.assertEqual(de["src"], "Translate into German: Hello")
         self.assertEqual(fr["src"], "Translate into French: Hello")
 
+    def test_chat_transform_uses_hf_additional_fields_in_dataset_prompt(self):
+        corpus = ParallelCorpus(
+            "de",
+            "hf://google/wmt24pp/en-de_DE/source",
+            "hf://google/wmt24pp/en-de_DE/target",
+            additional_fields=["domain", "document_id"],
+        )
+        rows = [
+            {
+                "source": "Hello",
+                "target": "Hallo",
+                "domain": "news",
+                "document_id": "doc-1",
+            }
+        ]
+        with patch.object(ParallelCorpus, "_load_hf_dataset", return_value=rows):
+            example = next(corpus.load())
+
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={
+                "de": Dataset(
+                    path_src="hf://google/wmt24pp/en-de_DE/source",
+                    path_tgt="hf://google/wmt24pp/en-de_DE/target",
+                    additional_fields=["domain", "document_id"],
+                    transforms=["chat"],
+                    transforms_configs={
+                        "chat": {
+                            "messages": [
+                                {
+                                    "role": "user",
+                                    "content": "Domain: {domain}\nDocument: {document_id}\nEnglish: {src}\nGerman:",
+                                }
+                            ]
+                        }
+                    },
+                )
+            },
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": []}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        transformed = transform.apply(example, corpus_name="de")
+
+        self.assertEqual(transformed["src"], "Domain: news\nDocument: doc-1\nEnglish: Hello\nGerman:")
+
     def test_chat_transform_dataset_override_inherits_omitted_global_keys(self):
         transforms_cls = get_transforms_cls(["chat"])
         opt = TrainConfig(
@@ -356,6 +470,22 @@ class TestTransform(unittest.TestCase):
         transformed = transform.apply({"src": "Hello"}, corpus_name="de")
 
         self.assertEqual(transformed["src"], "Translate into German: Hello")
+
+    def test_chat_transform_missing_formatted_field_suggests_additional_fields(self):
+        transforms_cls = get_transforms_cls(["chat"])
+        opt = TrainConfig(
+            data={"de": Dataset(path_src="eole/tests/data/src-train.txt", transforms=["chat"])},
+            src_vocab="dummy",
+            share_vocab=True,
+            transforms_configs={"chat": {"messages": [{"role": "user", "content": "Domain: {domain}\n{src}"}]}},
+            inference={"chat_template": "{{ messages[0].content }}"},
+            model=CustomModelConfig(),
+        )
+        transform = transforms_cls["chat"](opt)
+        transform.warm_up()
+
+        with self.assertRaisesRegex(ValueError, "domain.*additional_fields"):
+            transform.apply({"src": "Hello"}, corpus_name="de")
 
     def test_chat_transform_unknown_corpus_falls_back_to_global_config(self):
         transforms_cls = get_transforms_cls(["chat"])

--- a/eole/transforms/chat.py
+++ b/eole/transforms/chat.py
@@ -1,0 +1,139 @@
+"""Chat-template transforms for instruction and chat-style datasets."""
+
+from typing import Any, Dict, List
+
+from jinja2 import Environment, StrictUndefined
+from pydantic import Field
+
+from eole.transforms import register_transform
+from .transform import Transform, TransformConfig
+
+
+class ChatConfig(TransformConfig):
+    messages: List[Dict[str, Any]] = Field(default_factory=list, description="Messages to render into a chat prompt.")
+    add_generation_prompt: bool = Field(default=True, description="Append the assistant generation prompt.")
+    chat_template_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Extra variables to pass to the chat template renderer."
+    )
+    target: Dict[str, Any] = Field(default_factory=dict, description="Optional target normalization settings.")
+
+
+@register_transform(name="chat")
+class ChatTransform(Transform):
+    """Render raw examples with the converted model's chat template."""
+
+    config_model = ChatConfig
+    supports_dataset_overrides = True
+
+    def _parse_config(self):
+        self.template = None
+        self.specials = {}
+        self.global_config = None
+        self.corpus_configs = {}
+        self.environment = Environment(undefined=StrictUndefined)
+        self.environment.globals["raise_exception"] = self._raise_exception
+        self.environment.globals["strftime_now"] = self._strftime_now
+
+    def warm_up(self, vocabs=None):
+        super().warm_up(vocabs)
+        self.specials = vocabs.get("specials", {}) if vocabs is not None else {}
+        inference_config = getattr(self.full_config, "inference", None)
+        self.template = getattr(inference_config, "chat_template", None) if inference_config is not None else None
+        if not self.template:
+            raise ValueError("chat transform requires inference.chat_template from the converted EOLE model config.")
+        self.compiled_template = self.environment.from_string(self.template)
+        self.global_config = self.config
+        self.corpus_configs = self._build_corpus_configs()
+        self._validate_messages_configured()
+
+    def _build_corpus_configs(self):
+        corpus_configs = {}
+        if getattr(self.full_config, "data", None) is None:
+            return corpus_configs
+        global_config = self.global_config.model_dump()
+        for corpus_name, corpus in self.full_config.data.items():
+            overrides = getattr(corpus, "transforms_configs", None) or {}
+            chat_override = overrides.get(self.name)
+            if chat_override is None:
+                continue
+            merged = {**global_config, **chat_override}
+            corpus_configs[corpus_name] = ChatConfig.model_validate(merged)
+        return corpus_configs
+
+    def _chat_corpora_without_messages(self):
+        missing = []
+        if getattr(self.full_config, "data", None) is None:
+            return missing
+        for corpus_name, corpus in self.full_config.data.items():
+            if self.name in (corpus.transforms or []) and corpus_name not in self.corpus_configs:
+                missing.append(corpus_name)
+        return missing
+
+    def _validate_messages_configured(self):
+        if self.global_config.messages:
+            return
+        missing = self._chat_corpora_without_messages()
+        if missing:
+            corpus_list = ", ".join(missing)
+            raise ValueError(
+                "chat transform requires global messages or dataset-level chat.messages overrides "
+                f"for each chat corpus. Missing messages for: {corpus_list}."
+            )
+
+    @staticmethod
+    def _raise_exception(message):
+        raise ValueError(message)
+
+    @staticmethod
+    def _strftime_now(format_string):
+        from datetime import datetime
+
+        return datetime.now().strftime(format_string)
+
+    @staticmethod
+    def _format_value(value, fields):
+        if isinstance(value, str):
+            return value.format(**fields)
+        if isinstance(value, list):
+            return [ChatTransform._format_value(item, fields) for item in value]
+        if isinstance(value, dict):
+            return {key: ChatTransform._format_value(item, fields) for key, item in value.items()}
+        return value
+
+    def _render_messages(self, example, config):
+        fields = dict(example)
+        messages = [self._format_value(message, fields) for message in config.messages]
+        render_kwargs = {
+            "messages": messages,
+            "add_generation_prompt": config.add_generation_prompt,
+            "tools": None,
+            "bos_token": self.specials.get("bos_token"),
+            "eos_token": self.specials.get("eos_token"),
+            "pad_token": self.specials.get("pad_token"),
+            "unk_token": self.specials.get("unk_token"),
+            **config.chat_template_kwargs,
+        }
+        return self.compiled_template.render(**render_kwargs)
+
+    @staticmethod
+    def _normalize_target(text, config):
+        if text is None:
+            return None
+        if config.target.get("strip_commas", False):
+            text = text.replace(",", "")
+        return text
+
+    def apply(self, example, is_train=False, stats=None, **kwargs):
+        assert isinstance(example["src"], str), "ChatTransform requires a string source as input"
+        config = self.corpus_configs.get(kwargs.get("corpus_name"), self.global_config)
+        if not config.messages:
+            raise ValueError(
+                "chat transform has no messages for this corpus. Configure global chat.messages or a "
+                "dataset-level chat.messages override."
+            )
+        example["src"] = self._render_messages(example, config)
+        if example.get("tgt") is not None:
+            example["tgt"] = self._normalize_target(example["tgt"], config)
+            if "raw_tgt" in example:
+                example["raw_tgt"] = self._normalize_target(example["raw_tgt"], config)
+        return example

--- a/eole/transforms/chat.py
+++ b/eole/transforms/chat.py
@@ -93,7 +93,14 @@ class ChatTransform(Transform):
     @staticmethod
     def _format_value(value, fields):
         if isinstance(value, str):
-            return value.format(**fields)
+            try:
+                return value.format(**fields)
+            except KeyError as exc:
+                missing_field = exc.args[0]
+                raise ValueError(
+                    f"chat message references missing field {missing_field!r}; add it to the corpus "
+                    "additional_fields or check the spelling."
+                ) from exc
         if isinstance(value, list):
             return [ChatTransform._format_value(item, fields) for item in value]
         if isinstance(value, dict):

--- a/eole/transforms/tokenize_id.py
+++ b/eole/transforms/tokenize_id.py
@@ -92,7 +92,15 @@ class HuggingfaceTokenizer(IntTokenizerTransform):
 
     def tokenize_string(self, string, side="src", is_train=False):
         encoding = self.tokenizer.encode(string.replace(DefaultTokens.SEP, "\n"))
-        return encoding.ids, encoding.tokens
+        ids, tokens = encoding.ids, encoding.tokens
+        if self.max_length is not None:
+            max_length = self.max_length
+            decoder_start_token = self.full_config.decoder_start_token
+            if side == "tgt" and getattr(self.full_config.model, "encoder", None) is None and decoder_start_token == "":
+                # Decoder-only LM targets are shifted later, so keep one extra token to preserve legacy truncation.
+                max_length += 1
+            ids, tokens = ids[:max_length], tokens[:max_length]
+        return ids, tokens
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         assert isinstance(example["src"], str), "HuggingfaceTokenizer requires a string as input"

--- a/eole/transforms/tokenize_id.py
+++ b/eole/transforms/tokenize_id.py
@@ -92,15 +92,7 @@ class HuggingfaceTokenizer(IntTokenizerTransform):
 
     def tokenize_string(self, string, side="src", is_train=False):
         encoding = self.tokenizer.encode(string.replace(DefaultTokens.SEP, "\n"))
-        ids, tokens = encoding.ids, encoding.tokens
-        if self.max_length is not None:
-            max_length = self.max_length
-            decoder_start_token = self.full_config.decoder_start_token
-            if side == "tgt" and getattr(self.full_config.model, "encoder", None) is None and decoder_start_token == "":
-                # Decoder-only LM targets are shifted later, so keep one extra token to preserve legacy truncation.
-                max_length += 1
-            ids, tokens = ids[:max_length], tokens[:max_length]
-        return ids, tokens
+        return encoding.ids, encoding.tokens
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         assert isinstance(example["src"], str), "HuggingfaceTokenizer requires a string as input"

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         "fasttext-wheel",
         "huggingface_hub",
         "datasets",
+        "jinja2",
         "numpy>=2.0",
         "pandas",
         "protobuf==3.20.1",


### PR DESCRIPTION
This pull request introduces support for Hugging Face streaming datasets and dataset-level transform configuration overrides, along with a new `chat` transform for rendering chat-style prompts. It also improves tokenizer truncation and updates documentation to reflect these new features. The most important changes are grouped below:

**Hugging Face Streaming Dataset Support:**
- Added support for specifying datasets via `hf://` URIs in config files, allowing direct streaming from Hugging Face with flexible URI forms for split and config selection. All fields (source, target, score) must reference the same dataset/split except for the last field name. [[1]](diffhunk://#diff-3ce77db8624a22d0a9a4ccb6c282c4a44f967d4f289ae9d469dbaa83e146c89dR153-R221) [[2]](diffhunk://#diff-3ce77db8624a22d0a9a4ccb6c282c4a44f967d4f289ae9d469dbaa83e146c89dL162-R234) [[3]](diffhunk://#diff-3ce77db8624a22d0a9a4ccb6c282c4a44f967d4f289ae9d469dbaa83e146c89dR269-R278) [[4]](diffhunk://#diff-16d252183e366a6373b6bda8f32b312d1ff4dc1b8739ba5f87d16dd73ac5f820R88-R169)
- Improved internal parsing and validation for `hf://` URIs to ensure correct dataset, config, and split alignment between source and target fields. [[1]](diffhunk://#diff-3ce77db8624a22d0a9a4ccb6c282c4a44f967d4f289ae9d469dbaa83e146c89dR153-R221) [[2]](diffhunk://#diff-3ce77db8624a22d0a9a4ccb6c282c4a44f967d4f289ae9d469dbaa83e146c89dR269-R278)

**Dataset-Level Transform Overrides:**
- Introduced per-corpus `transforms_configs` in the data config, enabling dataset-level overrides for supported transforms (currently only `chat`). Validation ensures overrides are only used with enabled transforms that support them. [[1]](diffhunk://#diff-55bc0db727b3c2908b550c03bc4b7cde71652b1c66a1fc3ab8388f98dd04db60R75) [[2]](diffhunk://#diff-55bc0db727b3c2908b550c03bc4b7cde71652b1c66a1fc3ab8388f98dd04db60R235-R249) [[3]](diffhunk://#diff-16d252183e366a6373b6bda8f32b312d1ff4dc1b8739ba5f87d16dd73ac5f820R88-R169) [[4]](diffhunk://#diff-356e254cb3db1639142e20abc60a340167fee7931bd91b4f476580906c45cac6R151-R231)

**New Chat Transform:**
- Added a new `chat` transform (`eole.transforms.chat.ChatTransform`) to render chat-style prompts using a configurable message template, with support for dataset-level message overrides. [[1]](diffhunk://#diff-722b3e8c586b5a0a3f449c7ea88cbf78b01b609b1881f08241512bbd494fbec5R1-R139) [[2]](diffhunk://#diff-356e254cb3db1639142e20abc60a340167fee7931bd91b4f476580906c45cac6R151-R231) [[3]](diffhunk://#diff-16d252183e366a6373b6bda8f32b312d1ff4dc1b8739ba5f87d16dd73ac5f820R88-R169)
- The transform uses Jinja2 for template rendering and validates that each chat corpus has appropriate messages configured, either globally or via per-corpus overrides.

**Tokenizer Improvements:**
- Enhanced the Hugging Face tokenizer transform to truncate token IDs and strings according to `max_length`, with special handling for decoder-only models to preserve legacy truncation behavior.

**Documentation and Dependency Updates:**
- Updated documentation to describe Hugging Face streaming dataset usage, dataset-level transform overrides, and the new `chat` transform with configuration examples. [[1]](diffhunk://#diff-16d252183e366a6373b6bda8f32b312d1ff4dc1b8739ba5f87d16dd73ac5f820R88-R169) [[2]](diffhunk://#diff-356e254cb3db1639142e20abc60a340167fee7931bd91b4f476580906c45cac6R151-R231)
- Added `jinja2` as a new dependency for chat template rendering.