### PR TITLE
Add opt-in periodic device cache clearing during training

### DIFF
--- a/eole/config/training.py
+++ b/eole/config/training.py
@@ -184,6 +184,11 @@ class TrainingConfig(
         description="If the norm of the gradient vector exceeds this value, "
         "renormalize it to have the norm equal to max_grad_norm.",
     )
+    empty_cache_steps: int = Field(
+        default=0,
+        description="Every N optimizer steps, clear the active PyTorch device cache. "
+        "On MPS, also clear the graph cache when supported. Disabled when set to 0.",
+    )
     dropout: List[float] = Field(default=[0.3], description="Dropout probability.")
     attention_dropout: List[float] = Field(default=[0.1], description="Attention dropout probability.")
     dropout_steps: List[int] = Field(default=[0], description="Steps at which dropout changes.")

--- a/eole/tests/test_trainer_cache.py
+++ b/eole/tests/test_trainer_cache.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from eole.trainer import Trainer, TrainerConfig
+from eole.utils.misc import clear_gpu_cache
 
 
 class TestTrainerCacheClearing(unittest.TestCase):
@@ -10,59 +11,85 @@ class TestTrainerCacheClearing(unittest.TestCase):
         trainer = object.__new__(Trainer)
         trainer.config = TrainerConfig(empty_cache_steps=0)
 
-        with patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
+        with patch("eole.trainer.clear_gpu_cache") as clear_cache:
             trainer._maybe_clear_device_cache(step=1)
 
-        cuda_empty_cache.assert_not_called()
-        mps_empty_cache.assert_not_called()
+        clear_cache.assert_not_called()
 
     def test_empty_cache_steps_interval_mismatch_does_not_clear_cache(self):
         trainer = object.__new__(Trainer)
         trainer.config = TrainerConfig(empty_cache_steps=10)
 
-        with patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
+        with patch("eole.trainer.clear_gpu_cache") as clear_cache:
             trainer._maybe_clear_device_cache(step=9)
 
-        cuda_empty_cache.assert_not_called()
-        mps_empty_cache.assert_not_called()
+        clear_cache.assert_not_called()
+
+    def test_empty_cache_steps_interval_match_clears_cache(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10)
+
+        with patch("eole.trainer.clear_gpu_cache") as clear_cache:
+            trainer._maybe_clear_device_cache(step=10)
+
+        clear_cache.assert_called_once_with()
+
+    def test_training_loop_does_not_clear_cache_when_optimizer_step_is_skipped(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10, average_decay=0, n_gpu=0)
+        trainer.optim = SimpleNamespace(training_step=10, learning_rate=Mock(return_value=0.1))
+        trainer.scoring_preparator = SimpleNamespace(transforms=None)
+        trainer.model_saver = None
+        trainer.report_manager = None
+        trainer.earlystopper = None
+
+        trainer._accum_batches = Mock(return_value=iter([([], 1)]))
+        trainer._update_scheduled_params = Mock()
+        trainer._train_step = Mock()
+        trainer._maybe_clear_device_cache = Mock()
+
+        with patch("eole.trainer.clear_gpu_cache"):
+            trainer.train(train_iter=[], train_steps=10, valid_steps=1000)
+
+        trainer._maybe_clear_device_cache.assert_not_called()
 
     def test_empty_cache_steps_clears_cuda_cache_when_available(self):
-        trainer = object.__new__(Trainer)
-        trainer.config = TrainerConfig(empty_cache_steps=10)
+        torch_mock = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=Mock(return_value=True), empty_cache=Mock()),
+            backends=SimpleNamespace(mps=SimpleNamespace(is_available=Mock(return_value=False))),
+            mps=SimpleNamespace(empty_cache=Mock()),
+        )
 
-        with patch("torch.cuda.is_available", return_value=True), patch(
-            "torch.backends.mps.is_available", return_value=False
-        ), patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
-            trainer._maybe_clear_device_cache(step=10)
+        with patch("eole.utils.misc.torch", torch_mock):
+            clear_gpu_cache()
 
-        cuda_empty_cache.assert_called_once_with()
-        mps_empty_cache.assert_not_called()
+        torch_mock.cuda.empty_cache.assert_called_once_with()
+        torch_mock.mps.empty_cache.assert_not_called()
 
     def test_empty_cache_steps_clears_mps_cache_and_graph_cache_when_available(self):
-        trainer = object.__new__(Trainer)
-        trainer.config = TrainerConfig(empty_cache_steps=10)
+        torch_mock = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=Mock(return_value=False), empty_cache=Mock()),
+            backends=SimpleNamespace(mps=SimpleNamespace(is_available=Mock(return_value=True))),
+            mps=SimpleNamespace(empty_cache=Mock(), clear_graph_cache=Mock()),
+        )
 
-        with patch("torch.cuda.is_available", return_value=False), patch(
-            "torch.backends.mps.is_available", return_value=True
-        ), patch("torch.mps.empty_cache") as mps_empty_cache, patch(
-            "torch.mps.clear_graph_cache", create=True
-        ) as clear_graph_cache:
-            trainer._maybe_clear_device_cache(step=10)
+        with patch("eole.utils.misc.torch", torch_mock):
+            clear_gpu_cache()
 
-        mps_empty_cache.assert_called_once_with()
-        clear_graph_cache.assert_called_once_with()
+        torch_mock.mps.empty_cache.assert_called_once_with()
+        torch_mock.mps.clear_graph_cache.assert_called_once_with()
 
     def test_empty_cache_steps_clears_mps_cache_without_graph_cache_when_unavailable(self):
-        trainer = object.__new__(Trainer)
-        trainer.config = TrainerConfig(empty_cache_steps=10)
-        mps = SimpleNamespace(empty_cache=Mock())
+        torch_mock = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=Mock(return_value=False), empty_cache=Mock()),
+            backends=SimpleNamespace(mps=SimpleNamespace(is_available=Mock(return_value=True))),
+            mps=SimpleNamespace(empty_cache=Mock()),
+        )
 
-        with patch("torch.cuda.is_available", return_value=False), patch(
-            "torch.backends.mps.is_available", return_value=True
-        ), patch("torch.mps", mps):
-            trainer._maybe_clear_device_cache(step=10)
+        with patch("eole.utils.misc.torch", torch_mock):
+            clear_gpu_cache()
 
-        mps.empty_cache.assert_called_once_with()
+        torch_mock.mps.empty_cache.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/eole/tests/test_trainer_cache.py
+++ b/eole/tests/test_trainer_cache.py
@@ -1,0 +1,69 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from eole.trainer import Trainer, TrainerConfig
+
+
+class TestTrainerCacheClearing(unittest.TestCase):
+    def test_empty_cache_steps_disabled_does_not_clear_cache(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=0)
+
+        with patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
+            trainer._maybe_clear_device_cache(step=1)
+
+        cuda_empty_cache.assert_not_called()
+        mps_empty_cache.assert_not_called()
+
+    def test_empty_cache_steps_interval_mismatch_does_not_clear_cache(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10)
+
+        with patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
+            trainer._maybe_clear_device_cache(step=9)
+
+        cuda_empty_cache.assert_not_called()
+        mps_empty_cache.assert_not_called()
+
+    def test_empty_cache_steps_clears_cuda_cache_when_available(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10)
+
+        with patch("torch.cuda.is_available", return_value=True), patch(
+            "torch.backends.mps.is_available", return_value=False
+        ), patch("torch.cuda.empty_cache") as cuda_empty_cache, patch("torch.mps.empty_cache") as mps_empty_cache:
+            trainer._maybe_clear_device_cache(step=10)
+
+        cuda_empty_cache.assert_called_once_with()
+        mps_empty_cache.assert_not_called()
+
+    def test_empty_cache_steps_clears_mps_cache_and_graph_cache_when_available(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10)
+
+        with patch("torch.cuda.is_available", return_value=False), patch(
+            "torch.backends.mps.is_available", return_value=True
+        ), patch("torch.mps.empty_cache") as mps_empty_cache, patch(
+            "torch.mps.clear_graph_cache", create=True
+        ) as clear_graph_cache:
+            trainer._maybe_clear_device_cache(step=10)
+
+        mps_empty_cache.assert_called_once_with()
+        clear_graph_cache.assert_called_once_with()
+
+    def test_empty_cache_steps_clears_mps_cache_without_graph_cache_when_unavailable(self):
+        trainer = object.__new__(Trainer)
+        trainer.config = TrainerConfig(empty_cache_steps=10)
+        mps = SimpleNamespace(empty_cache=Mock())
+
+        with patch("torch.cuda.is_available", return_value=False), patch(
+            "torch.backends.mps.is_available", return_value=True
+        ), patch("torch.mps", mps):
+            trainer._maybe_clear_device_cache(step=10)
+
+        mps.empty_cache.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -301,7 +301,8 @@ class Trainer:
 
             # Core training step (overridable by subclasses)
             self._train_step(batches, normalization, total_stats, report_stats, step=step)
-            self._maybe_clear_device_cache(step)
+            if self.optim.training_step > step:
+                self._maybe_clear_device_cache(step)
 
             # Update moving average
             if self.config.average_decay > 0 and i % self.config.average_every == 0:

--- a/eole/trainer.py
+++ b/eole/trainer.py
@@ -36,6 +36,7 @@ class TrainerConfig:
     attention_dropout: List[float] = None
     dropout_steps: List[int] = None
     zero_out_prompt_loss: bool = False
+    empty_cache_steps: int = 0
     estim_loss_lambda: List[float] = None
     estim_loss_lambda_steps: List[int] = None
 
@@ -300,6 +301,7 @@ class Trainer:
 
             # Core training step (overridable by subclasses)
             self._train_step(batches, normalization, total_stats, report_stats, step=step)
+            self._maybe_clear_device_cache(step)
 
             # Update moving average
             if self.config.average_decay > 0 and i % self.config.average_every == 0:
@@ -365,6 +367,11 @@ class Trainer:
             step: Current training step number.
         """
         self._process_accumulated_batches(batches, normalization, total_stats, report_stats)
+
+    def _maybe_clear_device_cache(self, step: int):
+        if self.config.empty_cache_steps <= 0 or step % self.config.empty_cache_steps != 0:
+            return
+        clear_gpu_cache()
 
     def _update_scheduled_params(self, step: int):
         """Update all scheduled parameters."""
@@ -656,6 +663,7 @@ def build_trainer(config, device_id, model, vocabs, optim, model_saver=None):
         attention_dropout=running_config.attention_dropout,
         dropout_steps=running_config.dropout_steps,
         zero_out_prompt_loss=running_config.zero_out_prompt_loss,
+        empty_cache_steps=running_config.empty_cache_steps,
         estim_loss_lambda=running_config.estim_loss_lambda,
         estim_loss_lambda_steps=running_config.estim_loss_lambda_steps,
     )

--- a/eole/utils/misc.py
+++ b/eole/utils/misc.py
@@ -77,6 +77,8 @@ def clear_gpu_cache():
         torch.cuda.empty_cache()
     if torch.backends.mps.is_available():
         torch.mps.empty_cache()
+        if hasattr(torch.mps, "clear_graph_cache"):
+            torch.mps.clear_graph_cache()
 
 
 def get_device_type():


### PR DESCRIPTION
## Summary

Adds an opt-in `training.empty_cache_steps` setting to periodically clear PyTorch device caches during training.

This is primarily useful for MPS training runs where cached allocator memory can grow over time with variable-shape workloads, with open issues in PyTorch for this.

On supported PyTorch versions, MPS graph cache clearing is also invoked via a guarded `torch.mps.clear_graph_cache()` call.

Default behavior is unchanged: `empty_cache_steps: 0` disables periodic clearing.

## Changes

- Add `training.empty_cache_steps`, defaulting to `0`.
- Reuse `clear_gpu_cache()` from the trainer loop when the configured interval matches.
- Extend `clear_gpu_cache()` to clear the MPS graph cache when available.
- Add mocked tests for disabled, interval mismatch, CUDA, MPS with graph cache, and MPS without graph cache.

## Notes

This should not affect training quality. It only clears cached device allocations and, when available, cached MPS graph objects. Model weights, gradients, optimizer state, batches, and loss computation are unchanged.

The main tradeoff is performance: lower intervals may reduce MPS memory pressure but can add cache-clearing/recompilation overhead.